### PR TITLE
fix: add missing go.sum h1 entry for golang.org/x/tools (breaks Docker build)

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -430,6 +430,7 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.41.0 h1:a9b8iMweWG+S0OBnlU36rzLp20z1Rp10w+IY2czHTQc=
 golang.org/x/tools v0.41.0/go.mod h1:XSY6eDqxVNiYgezAVqqCeihT4j1U2CCsqvH3WhQpnlg=
+golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=
 golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=


### PR DESCRIPTION
## Problem

The Docker build CI on `main` is failing with:

```
missing go.sum entry for module providing package golang.org/x/tools/go/loader (imported by github.com/swaggo/swag/v2)
make: *** [Makefile:153: vet] Error 1
```

This is a transitive dependency of `github.com/swaggo/swag/v2@v2.0.0-rc5`. The `go.sum` file has the `go.mod` hash for `golang.org/x/tools v0.42.0` but is missing the required `h1:` content hash.

## Fix

Added the missing `h1:` entry to `go.sum` by running:
```
go get github.com/swaggo/swag/v2@v2.0.0-rc5
```

## Root Cause

The revert commit `f4a84d3` (chore: revert unintended go.sum change) on the feature branch removed this entry, which was included in the merged PR.