### PR TITLE
fix: include cluster metadata when rebuilding payload.json

### DIFF
--- a/internal/bg/cluster_action.go
+++ b/internal/bg/cluster_action.go
@@ -105,6 +105,7 @@ func ClusterActionWorker(db *gorm.DB, baseURL string) archer.WorkerFn {
 			Preload("NodePools.Annotations").
 			Preload("NodePools.Taints").
 			Preload("NodePools.Servers.SshKey").
+			Preload("Metadata").
 			Where("id = ? AND organization_id = ?", args.ClusterID, args.OrgID).
 			First(&c).Error; err != nil {
 			updateRun("failed", fmt.Errorf("load cluster: %w", err).Error())


### PR DESCRIPTION
## Problem

Cluster metadata was being created correctly and included in the normal prepare flow, but `payload.json` could still be rebuilt without metadata through the cluster action path.

## Root Cause

`ClusterActionWorker` rebuilds the same payload JSON sent to the bastion, but it loaded the cluster without `Preload("Metadata")`.

That meant:
- `mapper.ClusterToDTO(c)` saw an empty `c.Metadata`
- `payload.json` was written without the metadata map
- containers consuming `/opt/gluekube/platform.json` would not see cluster metadata when payloads were generated from the action flow

## Fix

Add `Preload("Metadata")` to the cluster query in `internal/bg/cluster_action.go`.

## Validation

- `go test ./internal/bg`
