### PR TITLE
chore: Add workflow to cleanup old GHCR.io images

### DIFF
--- a/.github/workflows/cleanup_images.yaml
+++ b/.github/workflows/cleanup_images.yaml
@@ -1,0 +1,22 @@
+name: 'Remove old GHCR.io Images'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  cleanup-images:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Cleanup old images
+        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
+        with:
+          package: tools-api
+          exclude-tags: latest,main,v*
+          keep-n-tagged: 5
+          delete-untagged: true
+          delete-partial-images: true
+          older-than: 5 days


### PR DESCRIPTION
This workflow is scheduled to run daily and can also be triggered manually to remove old images from GHCR.io, keeping the latest and a specified number of tagged images.