### PR TITLE
fix(build): add missing go.sum hash for golang.org/x/tools v0.44.0

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -529,6 +529,7 @@ golang.org/x/tools v0.41.0/go.mod h1:XSY6eDqxVNiYgezAVqqCeihT4j1U2CCsqvH3WhQpnlg
 golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=
 golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
 golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=
+golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
 golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=


### PR DESCRIPTION
## Problem

`main`'s build has been red since ~July 6. Docker Publish fails at `make build` → `make vet`:

```
/go/pkg/mod/github.com/swaggo/swag/v2@v2.0.0-rc5/operation.go:18:2: missing go.sum entry for module providing package golang.org/x/tools/go/loader (imported by github.com/swaggo/swag/v2); to add:
	go get github.com/swaggo/swag/v2@v2.0.0-rc5
```

`go vet ./...` compiles `swaggo/swag/v2`, which imports `golang.org/x/tools/go/loader`. `go.sum` carried only the `/go.mod` hash for `golang.org/x/tools v0.44.0`, not the full-module `h1:` hash needed to actually build that package — so vet failed.

This failing `build` check was cascading onto **all 39 open PRs**, making them all show as `UNSTABLE`.

## Fix

`go get github.com/swaggo/swag/v2@v2.0.0-rc5` — adds the single missing `h1:` line to `go.sum`. `go.mod` is unchanged.

Verified locally: `go vet ./...` now exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)