### PR TITLE
fix(clusters): write only the columns each handler owns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+# A run is only interesting for the tip of a branch; cancel superseded ones.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    # `make test` downloads an embedded Postgres archive on first run, which
+    # setup-go's module cache does not cover.
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: go.mod
+
+      - name: Test
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ SDK_REPO_CLEAN      := $(call trim,$(SDK_REPO))
 SDK_PKG_CLEAN       := $(call trim,$(SDK_PKG))
 
 # --- phony targets ---
-.PHONY: all prepare ui-install ui-build ui swagger build clean fmt vet tidy upgrade \
+.PHONY: all prepare ui-install ui-build ui swagger build clean fmt vet tidy upgrade test \
         sdk sdk-go sdk-ts sdk-ts-ui sdk-all help dev ui-compress print-version \
         validate-spec check-tags doctor diff-swagger
 
@@ -151,6 +151,17 @@ fmt: ## go fmt ./...
 
 vet: ## go vet ./...
 	@$(GOCMD) vet ./...
+
+# Packages that embed generated artifacts (docs/openapi.json, internal/web/dist)
+# cannot compile on a fresh checkout, because those artifacts are gitignored and
+# produced by `make swagger` / `make ui-build`. Exclude them so `make test` works
+# from a bare clone; `go list -e` is required because plain `go list ./...`
+# returns nothing and exits non-zero when any package fails to load.
+TEST_PKGS = $(shell $(GOCMD) list -e ./... | grep -vE '^github.com/glueops/autoglue$$|/cmd$$|/docs$$|/internal/api$$|/internal/web$$')
+
+test: ## go test -race over packages that build without generated embeds
+	@test -n "$(TEST_PKGS)" || { echo ">> go list returned no packages"; exit 1; }
+	@$(GOCMD) test -race -count=1 $(TEST_PKGS)
 
 tidy: ## go mod tidy
 	@$(GOCMD) mod tidy

--- a/internal/handlers/cluster_attach_test.go
+++ b/internal/handlers/cluster_attach_test.go
@@ -307,11 +307,13 @@ func newAttachCluster(t *testing.T, db *gorm.DB, orgID uuid.UUID) models.Cluster
 func newTestCredential(t *testing.T, db *gorm.DB, orgID uuid.UUID) models.Credential {
 	t.Helper()
 	c := models.Credential{
-		OrganizationID:   orgID,
-		Provider:         "aws",
-		Kind:             "static",
-		ScopeKind:        "org",
-		ScopeFingerprint: strings.Repeat("0", 64),
+		OrganizationID: orgID,
+		Provider:       "aws",
+		Kind:           "static",
+		ScopeKind:      "org",
+		// Unique per credential: (org, provider, scope_kind, fingerprint) is a
+		// unique index, and a test may need several credentials in one org.
+		ScopeFingerprint: strings.ReplaceAll(uuid.NewString()+uuid.NewString(), "-", ""), // char(64)
 		Name:             "cred-" + uuid.NewString(),
 		EncryptedData:    "x",
 		IV:               "x",

--- a/internal/handlers/cluster_attach_test.go
+++ b/internal/handlers/cluster_attach_test.go
@@ -1,0 +1,454 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/glueops/autoglue/internal/api/httpmiddleware"
+	"github.com/glueops/autoglue/internal/config"
+	"github.com/glueops/autoglue/internal/models"
+	"github.com/glueops/autoglue/internal/testutil/pgtest"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+// The five cluster foreign keys managed by attach/detach handler pairs. Each is
+// a distinct column on `clusters`, and Terraform drives several of them
+// concurrently against the same row.
+type fkAttachCase struct {
+	name string
+	// column is the real database column, which is not always what the Go field
+	// name or the JSON tag suggests -- see glue_ops_load_balancer_id.
+	column     string
+	attach     func(*gorm.DB, config.Config) http.HandlerFunc
+	detach     func(*gorm.DB, config.Config) http.HandlerFunc
+	newTarget  func(*testing.T, *gorm.DB, uuid.UUID) uuid.UUID
+	bodyKey    string
+	targetCode string // error code when the target belongs to another org
+}
+
+func fkAttachCases() []fkAttachCase {
+	return []fkAttachCase{
+		{
+			name:       "captain_domain",
+			column:     "captain_domain_id",
+			attach:     AttachCaptainDomain,
+			detach:     DetachCaptainDomain,
+			newTarget:  func(t *testing.T, db *gorm.DB, org uuid.UUID) uuid.UUID { return newTestDomain(t, db, org).ID },
+			bodyKey:    "domain_id",
+			targetCode: "domain_not_found",
+		},
+		{
+			name:       "control_plane_record_set",
+			column:     "control_plane_record_set_id",
+			attach:     AttachControlPlaneRecordSet,
+			detach:     DetachControlPlaneRecordSet,
+			newTarget:  func(t *testing.T, db *gorm.DB, org uuid.UUID) uuid.UUID { return newTestRecordSet(t, db, org).ID },
+			bodyKey:    "record_set_id",
+			targetCode: "recordset_not_found",
+		},
+		{
+			name:       "apps_load_balancer",
+			column:     "apps_load_balancer_id",
+			attach:     AttachAppsLoadBalancer,
+			detach:     DetachAppsLoadBalancer,
+			newTarget:  func(t *testing.T, db *gorm.DB, org uuid.UUID) uuid.UUID { return newTestLoadBalancer(t, db, org).ID },
+			bodyKey:    "load_balancer_id",
+			targetCode: "lb_not_found",
+		},
+		{
+			name:       "glueops_load_balancer",
+			column:     "glue_ops_load_balancer_id",
+			attach:     AttachGlueOpsLoadBalancer,
+			detach:     DetachGlueOpsLoadBalancer,
+			newTarget:  func(t *testing.T, db *gorm.DB, org uuid.UUID) uuid.UUID { return newTestLoadBalancer(t, db, org).ID },
+			bodyKey:    "load_balancer_id",
+			targetCode: "lb_not_found",
+		},
+		{
+			name:       "bastion_server",
+			column:     "bastion_server_id",
+			attach:     AttachBastionServer,
+			detach:     DetachBastionServer,
+			newTarget:  func(t *testing.T, db *gorm.DB, org uuid.UUID) uuid.UUID { return newTestServer(t, db, org).ID },
+			bodyKey:    "server_id",
+			targetCode: "server_not_found",
+		},
+	}
+}
+
+func TestClusterAttach_Authorization(t *testing.T) {
+	db := pgtest.DB(t)
+	cfg := config.Config{}
+
+	for _, tc := range fkAttachCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			org := createTestOrg(t, db, "attach-authz")
+			other := createTestOrg(t, db, "attach-authz-other")
+			cluster := newAttachCluster(t, db, org.ID)
+			target := tc.newTarget(t, db, org.ID)
+			body := fmt.Sprintf(`{%q:%q}`, tc.bodyKey, target.String())
+
+			t.Run("403 without org", func(t *testing.T) {
+				rr := httptest.NewRecorder()
+				tc.attach(db, cfg).ServeHTTP(rr, clusterReq(http.MethodPost, body, nil, cluster.ID.String()))
+				assertStatusCode(t, rr, http.StatusForbidden, "org_required")
+			})
+
+			t.Run("400 on malformed cluster id", func(t *testing.T) {
+				rr := httptest.NewRecorder()
+				tc.attach(db, cfg).ServeHTTP(rr, clusterReq(http.MethodPost, body, &org.ID, "not-a-uuid"))
+				if rr.Code != http.StatusBadRequest {
+					t.Fatalf("expected 400, got %d body=%s", rr.Code, rr.Body.String())
+				}
+			})
+
+			t.Run("404 for a cluster in another org", func(t *testing.T) {
+				foreign := newAttachCluster(t, db, other.ID)
+				rr := httptest.NewRecorder()
+				tc.attach(db, cfg).ServeHTTP(rr, clusterReq(http.MethodPost, body, &org.ID, foreign.ID.String()))
+				// The code matters, not just the status: "not_found" is what
+				// distinguishes "no such cluster for you" from a target lookup
+				// failure, and it is why the pre-read before the write is kept.
+				assertStatusCode(t, rr, http.StatusNotFound, "not_found")
+			})
+
+			t.Run("404 for a target in another org", func(t *testing.T) {
+				foreignTarget := tc.newTarget(t, db, other.ID)
+				rr := httptest.NewRecorder()
+				b := fmt.Sprintf(`{%q:%q}`, tc.bodyKey, foreignTarget.String())
+				tc.attach(db, cfg).ServeHTTP(rr, clusterReq(http.MethodPost, b, &org.ID, cluster.ID.String()))
+				assertStatusCode(t, rr, http.StatusNotFound, tc.targetCode)
+			})
+		})
+	}
+}
+
+func TestClusterAttach_WritesItsOwnColumn(t *testing.T) {
+	db := pgtest.DB(t)
+	cfg := config.Config{}
+
+	for _, tc := range fkAttachCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			org := createTestOrg(t, db, "attach-writes")
+			cluster := newAttachCluster(t, db, org.ID)
+			target := tc.newTarget(t, db, org.ID)
+
+			rr := httptest.NewRecorder()
+			body := fmt.Sprintf(`{%q:%q}`, tc.bodyKey, target.String())
+			tc.attach(db, cfg).ServeHTTP(rr, clusterReq(http.MethodPost, body, &org.ID, cluster.ID.String()))
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+			}
+
+			// Assert against the database, not the response body: the response
+			// is rendered from an in-memory struct and can disagree with the row.
+			if got := clusterColumn(t, db, cluster.ID, tc.column); got == nil || *got != target.String() {
+				t.Fatalf("%s: expected column to be %s, got %v", tc.column, target, derefOrNil(got))
+			}
+			assertNeedsValidation(t, db, cluster.ID)
+		})
+	}
+}
+
+func TestClusterDetach_ClearsItsOwnColumn(t *testing.T) {
+	db := pgtest.DB(t)
+	cfg := config.Config{}
+
+	for _, tc := range fkAttachCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			org := createTestOrg(t, db, "detach-clears")
+			cluster := newAttachCluster(t, db, org.ID)
+			target := tc.newTarget(t, db, org.ID)
+
+			// Seed the attachment directly. If the fixture did not actually
+			// start attached, "the column is NULL" would pass for a handler
+			// that does nothing at all.
+			if err := db.Model(&models.Cluster{}).Where("id = ?", cluster.ID).
+				Update(tc.column, target).Error; err != nil {
+				t.Fatalf("seed %s: %v", tc.column, err)
+			}
+			if got := clusterColumn(t, db, cluster.ID, tc.column); got == nil || *got != target.String() {
+				t.Fatalf("fixture did not attach %s (got %v) -- the assertion below would be vacuous",
+					tc.column, derefOrNil(got))
+			}
+
+			rr := httptest.NewRecorder()
+			tc.detach(db, cfg).ServeHTTP(rr, clusterReq(http.MethodDelete, "", &org.ID, cluster.ID.String()))
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+			}
+
+			if got := clusterColumn(t, db, cluster.ID, tc.column); got != nil {
+				t.Fatalf("%s: expected NULL after detach, got %q", tc.column, *got)
+			}
+			assertNeedsValidation(t, db, cluster.ID)
+		})
+	}
+}
+
+func TestUpdateCluster_ClusterProviderWritesProviderColumn(t *testing.T) {
+	db := pgtest.DB(t)
+	org := createTestOrg(t, db, "update-provider")
+	cluster := newAttachCluster(t, db, org.ID)
+
+	rr := httptest.NewRecorder()
+	req := clusterReq(http.MethodPatch, `{"cluster_provider":"hetzner"}`, &org.ID, cluster.ID.String())
+	UpdateCluster(db, config.Config{}).ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	// The request field is cluster_provider; the column is provider.
+	var got models.Cluster
+	if err := db.First(&got, "id = ?", cluster.ID).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.Provider != "hetzner" {
+		t.Fatalf("expected provider=hetzner, got %q", got.Provider)
+	}
+	if got.Name != cluster.Name {
+		t.Fatalf("name should be untouched, got %q want %q", got.Name, cluster.Name)
+	}
+}
+
+func TestUpdateCluster_EmptyPatchPreservesEveryField(t *testing.T) {
+	db := pgtest.DB(t)
+	org := createTestOrg(t, db, "update-empty")
+	cluster := newAttachCluster(t, db, org.ID)
+
+	rr := httptest.NewRecorder()
+	UpdateCluster(db, config.Config{}).ServeHTTP(rr,
+		clusterReq(http.MethodPatch, `{}`, &org.ID, cluster.ID.String()))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	var got models.Cluster
+	if err := db.First(&got, "id = ?", cluster.ID).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	for _, f := range []struct{ name, got, want string }{
+		{"name", got.Name, cluster.Name},
+		{"provider", got.Provider, cluster.Provider},
+		{"region", got.Region, cluster.Region},
+		{"docker_image", got.DockerImage, cluster.DockerImage},
+		{"docker_tag", got.DockerTag, cluster.DockerTag},
+		{"random_token", got.RandomToken, cluster.RandomToken},
+	} {
+		if f.got != f.want {
+			t.Errorf("%s: an empty PATCH wiped it: got %q want %q", f.name, f.got, f.want)
+		}
+	}
+}
+
+func TestClearClusterKubeconfig_EmptiesAllThreeColumns(t *testing.T) {
+	db := pgtest.DB(t)
+	org := createTestOrg(t, db, "clear-kubeconfig")
+	cluster := newAttachCluster(t, db, org.ID)
+
+	if err := db.Model(&models.Cluster{}).Where("id = ?", cluster.ID).
+		Updates(map[string]any{
+			"encrypted_kubeconfig": "ciphertext",
+			"kube_iv":              "iv",
+			"kube_tag":             "tag",
+		}).Error; err != nil {
+		t.Fatalf("seed kubeconfig: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	ClearClusterKubeconfig(db, config.Config{}).ServeHTTP(rr,
+		clusterReq(http.MethodDelete, "", &org.ID, cluster.ID.String()))
+	if rr.Code != http.StatusOK && rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 2xx, got %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	// A revocation that returns success while leaving the ciphertext in place
+	// is the failure this guards against.
+	for _, col := range []string{"encrypted_kubeconfig", "kube_iv", "kube_tag"} {
+		got := clusterColumn(t, db, cluster.ID, col)
+		if got == nil || *got != "" {
+			t.Errorf("%s: expected empty after clear, got %v", col, derefOrNil(got))
+		}
+	}
+}
+
+// --- helpers ---
+
+// newAttachCluster creates a cluster in a state distinguishable from the
+// post-handler state: a status that is not pre_pending and a non-empty
+// last_error, so a handler that resets neither is visible.
+func newAttachCluster(t *testing.T, db *gorm.DB, orgID uuid.UUID) models.Cluster {
+	t.Helper()
+	c := models.Cluster{
+		OrganizationID: orgID,
+		Name:           "cluster-" + uuid.NewString(),
+		Provider:       "aws",
+		Region:         "us-west-2",
+		Status:         models.ClusterStatusReady,
+		LastError:      "previous failure",
+		DockerImage:    "ghcr.io/glueops/captain",
+		DockerTag:      "v1.2.3",
+		RandomToken:    uuid.NewString(),
+	}
+	if err := db.Create(&c).Error; err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+	return c
+}
+
+func newTestCredential(t *testing.T, db *gorm.DB, orgID uuid.UUID) models.Credential {
+	t.Helper()
+	c := models.Credential{
+		OrganizationID:   orgID,
+		Provider:         "aws",
+		Kind:             "static",
+		ScopeKind:        "org",
+		ScopeFingerprint: strings.Repeat("0", 64),
+		Name:             "cred-" + uuid.NewString(),
+		EncryptedData:    "x",
+		IV:               "x",
+		Tag:              "x",
+	}
+	if err := db.Create(&c).Error; err != nil {
+		t.Fatalf("create credential: %v", err)
+	}
+	return c
+}
+
+func newTestDomain(t *testing.T, db *gorm.DB, orgID uuid.UUID) models.Domain {
+	t.Helper()
+	d := models.Domain{
+		OrganizationID: orgID,
+		DomainName:     uuid.NewString()[:8] + ".example.com",
+		CredentialID:   newTestCredential(t, db, orgID).ID,
+	}
+	if err := db.Create(&d).Error; err != nil {
+		t.Fatalf("create domain: %v", err)
+	}
+	return d
+}
+
+func newTestRecordSet(t *testing.T, db *gorm.DB, orgID uuid.UUID) models.RecordSet {
+	t.Helper()
+	r := models.RecordSet{
+		DomainID: newTestDomain(t, db, orgID).ID,
+		Name:     "endpoint",
+		Type:     "A",
+		Values:   datatypes.JSON([]byte(`["1.2.3.4"]`)),
+	}
+	if err := db.Create(&r).Error; err != nil {
+		t.Fatalf("create record set: %v", err)
+	}
+	return r
+}
+
+func newTestLoadBalancer(t *testing.T, db *gorm.DB, orgID uuid.UUID) models.LoadBalancer {
+	t.Helper()
+	lb := models.LoadBalancer{
+		OrganizationID:   orgID,
+		Name:             "lb-" + uuid.NewString(),
+		Kind:             "network",
+		PublicIPAddress:  "1.2.3.4",
+		PrivateIPAddress: "10.0.0.4",
+	}
+	if err := db.Create(&lb).Error; err != nil {
+		t.Fatalf("create load balancer: %v", err)
+	}
+	return lb
+}
+
+func newTestServer(t *testing.T, db *gorm.DB, orgID uuid.UUID) models.Server {
+	t.Helper()
+	key := models.SshKey{Name: "key-" + uuid.NewString()}
+	key.OrganizationID = orgID
+	if err := db.Create(&key).Error; err != nil {
+		t.Fatalf("create ssh key: %v", err)
+	}
+	ip := "203.0.113.10"
+	s := models.Server{
+		OrganizationID:   orgID,
+		Hostname:         "bastion",
+		PublicIPAddress:  &ip, // required by Server.BeforeSave for role=bastion
+		PrivateIPAddress: "10.0.0.10",
+		SSHUser:          "cluster",
+		SshKeyID:         key.ID,
+		Role:             "bastion",
+	}
+	if err := db.Create(&s).Error; err != nil {
+		t.Fatalf("create server: %v", err)
+	}
+	return s
+}
+
+// clusterReq builds a request carrying a clusterID route param, and an org in
+// context only when orgID is non-nil.
+func clusterReq(method, body string, orgID *uuid.UUID, clusterID string) *http.Request {
+	r := httptest.NewRequest(method, "/clusters/"+clusterID, strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+
+	ctx := r.Context()
+	if orgID != nil {
+		ctx = httpmiddleware.WithOrg(ctx, &models.Organization{ID: *orgID})
+	}
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("clusterID", clusterID)
+	ctx = context.WithValue(ctx, chi.RouteCtxKey, routeCtx)
+	return r.WithContext(ctx)
+}
+
+// clusterColumn reads one column straight from the row. The column names are
+// test constants, never user input.
+func clusterColumn(t *testing.T, db *gorm.DB, clusterID uuid.UUID, column string) *string {
+	t.Helper()
+	var v *string
+	q := fmt.Sprintf("SELECT %s::text FROM clusters WHERE id = ?", column)
+	if err := db.Raw(q, clusterID).Scan(&v).Error; err != nil {
+		t.Fatalf("read %s: %v", column, err)
+	}
+	return v
+}
+
+func assertNeedsValidation(t *testing.T, db *gorm.DB, clusterID uuid.UUID) {
+	t.Helper()
+	var c models.Cluster
+	if err := db.First(&c, "id = ?", clusterID).Error; err != nil {
+		t.Fatalf("reload cluster: %v", err)
+	}
+	if c.Status != models.ClusterStatusPrePending {
+		t.Errorf("expected status %q, got %q", models.ClusterStatusPrePending, c.Status)
+	}
+	if c.LastError != "" {
+		t.Errorf("expected last_error to be cleared, got %q", c.LastError)
+	}
+}
+
+func assertStatusCode(t *testing.T, rr *httptest.ResponseRecorder, status int, code string) {
+	t.Helper()
+	if rr.Code != status {
+		t.Fatalf("expected %d, got %d body=%s", status, rr.Code, rr.Body.String())
+	}
+	var body struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode error body %q: %v", rr.Body.String(), err)
+	}
+	if body.Code != code {
+		t.Fatalf("expected error code %q, got %q", code, body.Code)
+	}
+}
+
+func derefOrNil(s *string) any {
+	if s == nil {
+		return nil
+	}
+	return *s
+}

--- a/internal/handlers/cluster_columns_test.go
+++ b/internal/handlers/cluster_columns_test.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/glueops/autoglue/internal/models"
+	"gorm.io/gorm/schema"
+)
+
+// The handlers in clusters.go address columns by name. GORM resolves a name it
+// does not recognise as a column in one of two ways, and only one of them is
+// loud:
+//
+//   - a name matching an association field (ControlPlaneRecordSet, one deleted
+//     "ID" away from ControlPlaneRecordSetID) resolves to a field with no
+//     column, so the assignment is dropped and the write reports success
+//   - anything else is passed through as a quoted identifier and fails at the
+//     database with SQLSTATE 42703
+//
+// The first is the dangerous one: it returns 200 having written nothing, which
+// is indistinguishable from a successful detach until a foreign key rejects the
+// delete later. These tests are what stands between that and production.
+func parseClusterSchema(t *testing.T) *schema.Schema {
+	t.Helper()
+	s, err := schema.Parse(&models.Cluster{}, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("parse cluster schema: %v", err)
+	}
+	return s
+}
+
+func TestClusterWritableColumnsAreRealColumns(t *testing.T) {
+	s := parseClusterSchema(t)
+
+	for _, col := range clusterWritableColumns {
+		f := s.LookUpField(col)
+		switch {
+		case f == nil:
+			t.Errorf("%q does not resolve to any field on models.Cluster", col)
+		case f.DBName == "":
+			// This is the silent-no-op case.
+			t.Errorf("%q resolves to an association, not a column: writing it would be a silent no-op", col)
+		case f.DBName != col:
+			// Guards the two names that do not follow from the Go field or the
+			// JSON tag, e.g. glueops_load_balancer_id vs glue_ops_load_balancer_id.
+			t.Errorf("%q resolves to column %q; use the column name", col, f.DBName)
+		}
+	}
+}
+
+func TestClusterImmutableColumnsAreNotWritable(t *testing.T) {
+	writable := map[string]bool{}
+	for _, c := range clusterWritableColumns {
+		writable[c] = true
+	}
+	for _, c := range clusterImmutableColumns {
+		if writable[c] {
+			t.Errorf("%q is listed as both writable and immutable", c)
+		}
+	}
+}
+
+// A new column on models.Cluster must be classified deliberately. Without this,
+// a column added later is silently neither writable nor immutable, and the
+// lists stop describing the table.
+func TestClusterColumnListsCoverTheTable(t *testing.T) {
+	s := parseClusterSchema(t)
+
+	actual := map[string]bool{}
+	for _, f := range s.Fields {
+		if f.DBName != "" {
+			actual[f.DBName] = true
+		}
+	}
+
+	classified := map[string]bool{}
+	for _, c := range append(append([]string{}, clusterWritableColumns...), clusterImmutableColumns...) {
+		classified[c] = true
+	}
+
+	var missing, unknown []string
+	for col := range actual {
+		if !classified[col] {
+			missing = append(missing, col)
+		}
+	}
+	for col := range classified {
+		if !actual[col] {
+			unknown = append(unknown, col)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(unknown)
+
+	if len(missing) > 0 {
+		t.Errorf("columns on models.Cluster that are neither writable nor immutable: %v"+
+			" -- add each to clusterWritableColumns or clusterImmutableColumns", missing)
+	}
+	if len(unknown) > 0 {
+		t.Errorf("columns listed but not present on models.Cluster: %v", unknown)
+	}
+}

--- a/internal/handlers/cluster_concurrent_write_test.go
+++ b/internal/handlers/cluster_concurrent_write_test.go
@@ -1,0 +1,156 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/glueops/autoglue/internal/config"
+	"github.com/glueops/autoglue/internal/models"
+	"github.com/glueops/autoglue/internal/testutil/pgtest"
+	"github.com/google/uuid"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// TestClusterDetach_DoesNotClobberAConcurrentSiblingWrite is the regression
+// test for the bug this file's handlers were changed to fix.
+//
+// OpenTofu destroys a cluster's attachments in parallel, so several detach
+// handlers run against the same row at once. When each one saved the whole
+// row, the last writer replayed every column from a snapshot taken before the
+// others had written, silently restoring a foreign key another handler had just
+// cleared. The delete of the referenced row then failed on that foreign key.
+//
+// Rather than race goroutines and hope, this drives the interleaving from a
+// GORM callback: the competing write is issued at the exact point between the
+// handler's read and its write.
+func TestClusterDetach_DoesNotClobberAConcurrentSiblingWrite(t *testing.T) {
+	shared := pgtest.DB(t)
+	dsn := pgtest.URL(t)
+	cfg := config.Config{}
+
+	for _, tc := range fkAttachCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			// Any column the handler under test does not own.
+			sibling := colClusterCaptainDomainID
+			if tc.column == sibling {
+				sibling = colClusterBastionServerID
+			}
+
+			org := createTestOrg(t, shared, "clobber-"+tc.name)
+			cluster := newAttachCluster(t, shared, org.ID)
+
+			own := tc.newTarget(t, shared, org.ID)
+			var siblingTarget uuid.UUID
+			if sibling == colClusterCaptainDomainID {
+				siblingTarget = newTestDomain(t, shared, org.ID).ID
+			} else {
+				siblingTarget = newTestServer(t, shared, org.ID).ID
+			}
+
+			if err := shared.Model(&models.Cluster{}).Where("id = ?", cluster.ID).
+				Updates(map[string]any{tc.column: own, sibling: siblingTarget}).Error; err != nil {
+				t.Fatalf("seed attachments: %v", err)
+			}
+
+			// A dedicated handle: callbacks are registered on the *gorm.DB and
+			// would otherwise leak into every other test sharing the pgtest one.
+			ded, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+			if err != nil {
+				t.Fatalf("open dedicated handle: %v", err)
+			}
+
+			fired := 0
+			err = ded.Callback().Update().Before("gorm:update").
+				Register("test:interleave", func(tx *gorm.DB) {
+					if tx.Statement.Table != "clusters" || fired > 0 {
+						return
+					}
+					fired++
+					// Issued on a different connection, so this is a genuinely
+					// separate transaction. Never use tx here: that would run
+					// inside the handler's own transaction and model nothing.
+					q := fmt.Sprintf("UPDATE clusters SET %s = NULL WHERE id = ?", sibling)
+					if e := shared.Exec(q, cluster.ID).Error; e != nil {
+						t.Errorf("competing write: %v", e)
+					}
+				})
+			if err != nil {
+				t.Fatalf("register callback: %v", err)
+			}
+
+			rr := httptest.NewRecorder()
+			tc.detach(ded, cfg).ServeHTTP(rr, clusterReq(http.MethodDelete, "", &org.ID, cluster.ID.String()))
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+			}
+
+			// Without this the test silently proves nothing if the callback
+			// stops firing (a GORM upgrade, a renamed processor, a handler that
+			// stops issuing an UPDATE at all).
+			if fired != 1 {
+				t.Fatalf("interleave fired %d times, want 1 -- the test is vacuous", fired)
+			}
+
+			if got := clusterColumn(t, shared, cluster.ID, tc.column); got != nil {
+				t.Errorf("%s: handler did not clear its own column, got %q", tc.column, *got)
+			}
+			if got := clusterColumn(t, shared, cluster.ID, sibling); got != nil {
+				t.Errorf("%s: the concurrent write was clobbered -- the handler replayed a stale value (%q)",
+					sibling, *got)
+			}
+		})
+	}
+}
+
+// A detach arriving after the cluster row is gone must not recreate it.
+// db.Save falls back to an INSERT when its UPDATE matches no rows, which
+// resurrected deleted clusters with every stale foreign key restored.
+func TestClusterDetach_DoesNotResurrectADeletedCluster(t *testing.T) {
+	shared := pgtest.DB(t)
+	dsn := pgtest.URL(t)
+	cfg := config.Config{}
+
+	org := createTestOrg(t, shared, "resurrect")
+	cluster := newAttachCluster(t, shared, org.ID)
+
+	ded, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open dedicated handle: %v", err)
+	}
+
+	fired := 0
+	err = ded.Callback().Update().Before("gorm:update").
+		Register("test:delete-underneath", func(tx *gorm.DB) {
+			if tx.Statement.Table != "clusters" || fired > 0 {
+				return
+			}
+			fired++
+			if e := shared.Exec("DELETE FROM clusters WHERE id = ?", cluster.ID).Error; e != nil {
+				t.Errorf("delete underneath: %v", e)
+			}
+		})
+	if err != nil {
+		t.Fatalf("register callback: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	DetachCaptainDomain(ded, cfg).ServeHTTP(rr, clusterReq(http.MethodDelete, "", &org.ID, cluster.ID.String()))
+
+	if fired != 1 {
+		t.Fatalf("interleave fired %d times, want 1 -- the test is vacuous", fired)
+	}
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 once the row is gone, got %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	var count int64
+	if err := shared.Model(&models.Cluster{}).Where("id = ?", cluster.ID).Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("the deleted cluster was recreated by the detach")
+	}
+}

--- a/internal/handlers/clusters.go
+++ b/internal/handlers/clusters.go
@@ -21,6 +21,70 @@ import (
 	"gorm.io/gorm"
 )
 
+// Column names on the clusters table.
+//
+// These handlers write individual columns rather than saving the whole row: a
+// whole-row write replays every column from a snapshot taken before the read,
+// so two concurrent requests silently undo each other's changes. Writing only
+// the columns a handler owns makes them commutative.
+//
+// Two of these names do not follow from the Go field or the JSON tag:
+//   - the column is glue_ops_load_balancer_id; the JSON tag is glueops_load_balancer_id
+//   - the column is provider; the request field is cluster_provider
+//
+// cluster_columns_test.go asserts every name here is a real, writable column,
+// which is the only protection against a name that silently writes nothing:
+// GORM resolves an association field (ControlPlaneRecordSet) to a field with no
+// column and drops the assignment, reporting success.
+const (
+	colClusterName                    = "name"
+	colClusterProvider                = "provider"
+	colClusterRegion                  = "region"
+	colClusterStatus                  = "status"
+	colClusterLastError               = "last_error"
+	colClusterCaptainDomainID         = "captain_domain_id"
+	colClusterControlPlaneRecordSetID = "control_plane_record_set_id"
+	colClusterAppsLoadBalancerID      = "apps_load_balancer_id"
+	colClusterGlueOpsLoadBalancerID   = "glue_ops_load_balancer_id"
+	colClusterBastionServerID         = "bastion_server_id"
+	colClusterEncryptedKubeconfig     = "encrypted_kubeconfig"
+	colClusterKubeIV                  = "kube_iv"
+	colClusterKubeTag                 = "kube_tag"
+	colClusterDockerImage             = "docker_image"
+	colClusterDockerTag               = "docker_tag"
+)
+
+// clusterWritableColumns is every column the handlers in this file write.
+var clusterWritableColumns = []string{
+	colClusterName,
+	colClusterProvider,
+	colClusterRegion,
+	colClusterStatus,
+	colClusterLastError,
+	colClusterCaptainDomainID,
+	colClusterControlPlaneRecordSetID,
+	colClusterAppsLoadBalancerID,
+	colClusterGlueOpsLoadBalancerID,
+	colClusterBastionServerID,
+	colClusterEncryptedKubeconfig,
+	colClusterKubeIV,
+	colClusterKubeTag,
+	colClusterDockerImage,
+	colClusterDockerTag,
+}
+
+// clusterImmutableColumns is every remaining column on the table. Together the
+// two lists must cover models.Cluster exactly, so a new column has to be
+// classified deliberately rather than defaulting to writable.
+var clusterImmutableColumns = []string{
+	"id",
+	"organization_id",
+	"random_token",
+	"certificate_key",
+	"created_at",
+	"updated_at",
+}
+
 // ListClusters godoc
 //
 //	@ID				ListClusters
@@ -277,51 +341,53 @@ func UpdateCluster(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		// Apply only provided fields
+		// Apply only provided fields. Keys are hardcoded, never taken from the
+		// request: a map keyed from request JSON would make organization_id and
+		// the kubeadm credentials writable by any caller.
+		updates := map[string]any{
+			colClusterStatus:    models.ClusterStatusPrePending,
+			colClusterLastError: "",
+		}
 		if in.Name != nil {
-			cluster.Name = *in.Name
+			updates[colClusterName] = *in.Name
 		}
 		if in.ClusterProvider != nil {
-			cluster.Provider = *in.ClusterProvider
+			updates[colClusterProvider] = *in.ClusterProvider
 		}
 		if in.Region != nil {
-			cluster.Region = *in.Region
+			updates[colClusterRegion] = *in.Region
 		}
-
 		if in.DockerImage != nil {
-			cluster.DockerImage = *in.DockerImage
+			updates[colClusterDockerImage] = *in.DockerImage
 		}
-
 		if in.DockerTag != nil {
-			cluster.DockerTag = *in.DockerTag
+			updates[colClusterDockerTag] = *in.DockerTag
 		}
 
-		if err := db.Save(&cluster).Error; err != nil {
+		res := db.Model(&models.Cluster{}).
+			Where("id = ? AND organization_id = ?", clusterID, orgID).
+			Updates(updates)
+		if res.Error != nil {
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
-
-		// Any change to the cluster config may require re-validation.
-		_ = markClusterNeedsValidation(db, cluster.ID)
+		if res.RowsAffected == 0 {
+			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+			return
+		}
 
 		// Preload for a rich response
-		if err := db.Preload("CaptainDomain").
-			Preload("ControlPlaneRecordSet").
-			Preload("AppsLoadBalancer").
-			Preload("GlueOpsLoadBalancer").
-			Preload("BastionServer").
-			Preload("NodePools").
-			Preload("NodePools.Labels").
-			Preload("NodePools.Annotations").
-			Preload("NodePools.Taints").
-			Preload("NodePools.Servers").
-			Preload("Metadata").
-			First(&cluster, "id = ?", cluster.ID).Error; err != nil {
+		out, err := loadClusterForResponse(db, cluster.ID, orgID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+				return
+			}
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
 
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(cluster, cfg))
+		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
 	}
 }
 
@@ -434,33 +500,34 @@ func AttachCaptainDomain(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		cluster.CaptainDomainID = &domain.ID
-		if err := db.Save(&cluster).Error; err != nil {
+		res := db.Model(&models.Cluster{}).
+			Where("id = ? AND organization_id = ?", clusterID, orgID).
+			Updates(map[string]any{
+				colClusterCaptainDomainID: domain.ID,
+				colClusterStatus:          models.ClusterStatusPrePending,
+				colClusterLastError:       "",
+			})
+		if res.Error != nil {
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
-
-		if err := markClusterNeedsValidation(db, cluster.ID); err != nil {
-			// Don't fail the request, just log if you have logging.
+		if res.RowsAffected == 0 {
+			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+			return
 		}
 
 		// Preload domain for response
-		if err := db.Preload("CaptainDomain").
-			Preload("ControlPlaneRecordSet").
-			Preload("AppsLoadBalancer").
-			Preload("GlueOpsLoadBalancer").
-			Preload("BastionServer").
-			Preload("NodePools").
-			Preload("NodePools.Labels").
-			Preload("NodePools.Annotations").
-			Preload("NodePools.Taints").
-			Preload("NodePools.Servers").
-			Preload("Metadata").
-			First(&cluster, "id = ?", cluster.ID).Error; err != nil {
+		out, err := loadClusterForResponse(db, cluster.ID, orgID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+				return
+			}
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(cluster, cfg))
+
+		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
 	}
 }
 
@@ -507,31 +574,33 @@ func DetachCaptainDomain(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		cluster.CaptainDomainID = nil
-		if err := db.Save(&cluster).Error; err != nil {
+		res := db.Model(&models.Cluster{}).
+			Where("id = ? AND organization_id = ?", clusterID, orgID).
+			Updates(map[string]any{
+				colClusterCaptainDomainID: nil,
+				colClusterStatus:          models.ClusterStatusPrePending,
+				colClusterLastError:       "",
+			})
+		if res.Error != nil {
+			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
+			return
+		}
+		if res.RowsAffected == 0 {
+			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+			return
+		}
+
+		out, err := loadClusterForResponse(db, cluster.ID, orgID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+				return
+			}
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
 
-		_ = markClusterNeedsValidation(db, cluster.ID)
-
-		if err := db.Preload("CaptainDomain").
-			Preload("ControlPlaneRecordSet").
-			Preload("AppsLoadBalancer").
-			Preload("GlueOpsLoadBalancer").
-			Preload("BastionServer").
-			Preload("NodePools").
-			Preload("NodePools.Labels").
-			Preload("NodePools.Annotations").
-			Preload("NodePools.Taints").
-			Preload("NodePools.Servers").
-			Preload("Metadata").
-			First(&cluster, "id = ?", cluster.ID).Error; err != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(cluster, cfg))
+		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
 	}
 }
 
@@ -600,31 +669,33 @@ func AttachControlPlaneRecordSet(db *gorm.DB, cfg config.Config) http.HandlerFun
 			return
 		}
 
-		cluster.ControlPlaneRecordSetID = &rs.ID
-		if err := db.Save(&cluster).Error; err != nil {
+		res := db.Model(&models.Cluster{}).
+			Where("id = ? AND organization_id = ?", clusterID, orgID).
+			Updates(map[string]any{
+				colClusterControlPlaneRecordSetID: rs.ID,
+				colClusterStatus:                  models.ClusterStatusPrePending,
+				colClusterLastError:               "",
+			})
+		if res.Error != nil {
+			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
+			return
+		}
+		if res.RowsAffected == 0 {
+			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+			return
+		}
+
+		out, err := loadClusterForResponse(db, cluster.ID, orgID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+				return
+			}
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
 
-		_ = markClusterNeedsValidation(db, cluster.ID)
-
-		if err := db.Preload("CaptainDomain").
-			Preload("ControlPlaneRecordSet").
-			Preload("AppsLoadBalancer").
-			Preload("GlueOpsLoadBalancer").
-			Preload("BastionServer").
-			Preload("NodePools").
-			Preload("NodePools.Labels").
-			Preload("NodePools.Annotations").
-			Preload("NodePools.Taints").
-			Preload("NodePools.Servers").
-			Preload("Metadata").
-			First(&cluster, "id = ?", cluster.ID).Error; err != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(cluster, cfg))
+		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
 	}
 }
 
@@ -671,31 +742,33 @@ func DetachControlPlaneRecordSet(db *gorm.DB, cfg config.Config) http.HandlerFun
 			return
 		}
 
-		cluster.ControlPlaneRecordSetID = nil
-		if err := db.Save(&cluster).Error; err != nil {
+		res := db.Model(&models.Cluster{}).
+			Where("id = ? AND organization_id = ?", clusterID, orgID).
+			Updates(map[string]any{
+				colClusterControlPlaneRecordSetID: nil,
+				colClusterStatus:                  models.ClusterStatusPrePending,
+				colClusterLastError:               "",
+			})
+		if res.Error != nil {
+			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
+			return
+		}
+		if res.RowsAffected == 0 {
+			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+			return
+		}
+
+		out, err := loadClusterForResponse(db, cluster.ID, orgID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+				return
+			}
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
 
-		_ = markClusterNeedsValidation(db, cluster.ID)
-
-		if err := db.Preload("CaptainDomain").
-			Preload("ControlPlaneRecordSet").
-			Preload("AppsLoadBalancer").
-			Preload("GlueOpsLoadBalancer").
-			Preload("BastionServer").
-			Preload("NodePools").
-			Preload("NodePools.Labels").
-			Preload("NodePools.Annotations").
-			Preload("NodePools.Taints").
-			Preload("NodePools.Servers").
-			Preload("Metadata").
-			First(&cluster, "id = ?", cluster.ID).Error; err != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(cluster, cfg))
+		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
 	}
 }
 
@@ -760,31 +833,33 @@ func AttachAppsLoadBalancer(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		cluster.AppsLoadBalancerID = &lb.ID
-		if err := db.Save(&cluster).Error; err != nil {
+		res := db.Model(&models.Cluster{}).
+			Where("id = ? AND organization_id = ?", clusterID, orgID).
+			Updates(map[string]any{
+				colClusterAppsLoadBalancerID: lb.ID,
+				colClusterStatus:             models.ClusterStatusPrePending,
+				colClusterLastError:          "",
+			})
+		if res.Error != nil {
+			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
+			return
+		}
+		if res.RowsAffected == 0 {
+			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+			return
+		}
+
+		out, err := loadClusterForResponse(db, cluster.ID, orgID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+				return
+			}
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
 
-		_ = markClusterNeedsValidation(db, cluster.ID)
-
-		if err := db.Preload("CaptainDomain").
-			Preload("ControlPlaneRecordSet").
-			Preload("AppsLoadBalancer").
-			Preload("GlueOpsLoadBalancer").
-			Preload("BastionServer").
-			Preload("NodePools").
-			Preload("NodePools.Labels").
-			Preload("NodePools.Annotations").
-			Preload("NodePools.Taints").
-			Preload("NodePools.Servers").
-			Preload("Metadata").
-			First(&cluster, "id = ?", cluster.ID).Error; err != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(cluster, cfg))
+		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
 	}
 }
 
@@ -831,31 +906,33 @@ func DetachAppsLoadBalancer(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		cluster.AppsLoadBalancerID = nil
-		if err := db.Save(&cluster).Error; err != nil {
+		res := db.Model(&models.Cluster{}).
+			Where("id = ? AND organization_id = ?", clusterID, orgID).
+			Updates(map[string]any{
+				colClusterAppsLoadBalancerID: nil,
+				colClusterStatus:             models.ClusterStatusPrePending,
+				colClusterLastError:          "",
+			})
+		if res.Error != nil {
+			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
+			return
+		}
+		if res.RowsAffected == 0 {
+			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+			return
+		}
+
+		out, err := loadClusterForResponse(db, cluster.ID, orgID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+				return
+			}
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
 
-		_ = markClusterNeedsValidation(db, cluster.ID)
-
-		if err := db.Preload("CaptainDomain").
-			Preload("ControlPlaneRecordSet").
-			Preload("AppsLoadBalancer").
-			Preload("GlueOpsLoadBalancer").
-			Preload("BastionServer").
-			Preload("NodePools").
-			Preload("NodePools.Labels").
-			Preload("NodePools.Annotations").
-			Preload("NodePools.Taints").
-			Preload("NodePools.Servers").
-			Preload("Metadata").
-			First(&cluster, "id = ?", cluster.ID).Error; err != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(cluster, cfg))
+		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
 	}
 }
 
@@ -920,31 +997,33 @@ func AttachGlueOpsLoadBalancer(db *gorm.DB, cfg config.Config) http.HandlerFunc 
 			return
 		}
 
-		cluster.GlueOpsLoadBalancerID = &lb.ID
-		if err := db.Save(&cluster).Error; err != nil {
+		res := db.Model(&models.Cluster{}).
+			Where("id = ? AND organization_id = ?", clusterID, orgID).
+			Updates(map[string]any{
+				colClusterGlueOpsLoadBalancerID: lb.ID,
+				colClusterStatus:                models.ClusterStatusPrePending,
+				colClusterLastError:             "",
+			})
+		if res.Error != nil {
+			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
+			return
+		}
+		if res.RowsAffected == 0 {
+			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+			return
+		}
+
+		out, err := loadClusterForResponse(db, cluster.ID, orgID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+				return
+			}
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
 
-		_ = markClusterNeedsValidation(db, cluster.ID)
-
-		if err := db.Preload("CaptainDomain").
-			Preload("ControlPlaneRecordSet").
-			Preload("AppsLoadBalancer").
-			Preload("GlueOpsLoadBalancer").
-			Preload("BastionServer").
-			Preload("NodePools").
-			Preload("NodePools.Labels").
-			Preload("NodePools.Annotations").
-			Preload("NodePools.Taints").
-			Preload("NodePools.Servers").
-			Preload("Metadata").
-			First(&cluster, "id = ?", cluster.ID).Error; err != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(cluster, cfg))
+		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
 	}
 }
 
@@ -991,31 +1070,33 @@ func DetachGlueOpsLoadBalancer(db *gorm.DB, cfg config.Config) http.HandlerFunc 
 			return
 		}
 
-		cluster.GlueOpsLoadBalancerID = nil
-		if err := db.Save(&cluster).Error; err != nil {
+		res := db.Model(&models.Cluster{}).
+			Where("id = ? AND organization_id = ?", clusterID, orgID).
+			Updates(map[string]any{
+				colClusterGlueOpsLoadBalancerID: nil,
+				colClusterStatus:                models.ClusterStatusPrePending,
+				colClusterLastError:             "",
+			})
+		if res.Error != nil {
+			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
+			return
+		}
+		if res.RowsAffected == 0 {
+			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+			return
+		}
+
+		out, err := loadClusterForResponse(db, cluster.ID, orgID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+				return
+			}
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
 
-		_ = markClusterNeedsValidation(db, cluster.ID)
-
-		if err := db.Preload("CaptainDomain").
-			Preload("ControlPlaneRecordSet").
-			Preload("AppsLoadBalancer").
-			Preload("GlueOpsLoadBalancer").
-			Preload("BastionServer").
-			Preload("NodePools").
-			Preload("NodePools.Labels").
-			Preload("NodePools.Annotations").
-			Preload("NodePools.Taints").
-			Preload("NodePools.Servers").
-			Preload("Metadata").
-			First(&cluster, "id = ?", cluster.ID).Error; err != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(cluster, cfg))
+		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
 	}
 }
 
@@ -1080,31 +1161,33 @@ func AttachBastionServer(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		cluster.BastionServerID = &server.ID
-		if err := db.Save(&cluster).Error; err != nil {
+		res := db.Model(&models.Cluster{}).
+			Where("id = ? AND organization_id = ?", clusterID, orgID).
+			Updates(map[string]any{
+				colClusterBastionServerID: server.ID,
+				colClusterStatus:          models.ClusterStatusPrePending,
+				colClusterLastError:       "",
+			})
+		if res.Error != nil {
+			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
+			return
+		}
+		if res.RowsAffected == 0 {
+			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+			return
+		}
+
+		out, err := loadClusterForResponse(db, cluster.ID, orgID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+				return
+			}
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
 
-		_ = markClusterNeedsValidation(db, cluster.ID)
-
-		if err := db.Preload("CaptainDomain").
-			Preload("ControlPlaneRecordSet").
-			Preload("AppsLoadBalancer").
-			Preload("GlueOpsLoadBalancer").
-			Preload("BastionServer").
-			Preload("NodePools").
-			Preload("NodePools.Labels").
-			Preload("NodePools.Annotations").
-			Preload("NodePools.Taints").
-			Preload("NodePools.Servers").
-			Preload("Metadata").
-			First(&cluster, "id = ?", cluster.ID).Error; err != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(cluster, cfg))
+		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
 	}
 }
 
@@ -1151,31 +1234,33 @@ func DetachBastionServer(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		cluster.BastionServerID = nil
-		if err := db.Save(&cluster).Error; err != nil {
+		res := db.Model(&models.Cluster{}).
+			Where("id = ? AND organization_id = ?", clusterID, orgID).
+			Updates(map[string]any{
+				colClusterBastionServerID: nil,
+				colClusterStatus:          models.ClusterStatusPrePending,
+				colClusterLastError:       "",
+			})
+		if res.Error != nil {
+			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
+			return
+		}
+		if res.RowsAffected == 0 {
+			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+			return
+		}
+
+		out, err := loadClusterForResponse(db, cluster.ID, orgID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+				return
+			}
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
 
-		_ = markClusterNeedsValidation(db, cluster.ID)
-
-		if err := db.Preload("CaptainDomain").
-			Preload("ControlPlaneRecordSet").
-			Preload("AppsLoadBalancer").
-			Preload("GlueOpsLoadBalancer").
-			Preload("BastionServer").
-			Preload("NodePools").
-			Preload("NodePools.Labels").
-			Preload("NodePools.Annotations").
-			Preload("NodePools.Taints").
-			Preload("NodePools.Servers").
-			Preload("Metadata").
-			First(&cluster, "id = ?", cluster.ID).Error; err != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(cluster, cfg))
+		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
 	}
 }
 
@@ -1236,34 +1321,35 @@ func SetClusterKubeconfig(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		cluster.EncryptedKubeconfig = ct
-		cluster.KubeIV = iv
-		cluster.KubeTag = tag
+		res := db.Model(&models.Cluster{}).
+			Where("id = ? AND organization_id = ?", clusterID, orgID).
+			Updates(map[string]any{
+				colClusterEncryptedKubeconfig: ct,
+				colClusterKubeIV:              iv,
+				colClusterKubeTag:             tag,
+				colClusterStatus:              models.ClusterStatusPrePending,
+				colClusterLastError:           "",
+			})
+		if res.Error != nil {
+			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
+			return
+		}
+		if res.RowsAffected == 0 {
+			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+			return
+		}
 
-		if err := db.Save(&cluster).Error; err != nil {
+		out, err := loadClusterForResponse(db, cluster.ID, orgID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+				return
+			}
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
 
-		_ = markClusterNeedsValidation(db, cluster.ID)
-
-		if err := db.Preload("CaptainDomain").
-			Preload("ControlPlaneRecordSet").
-			Preload("AppsLoadBalancer").
-			Preload("GlueOpsLoadBalancer").
-			Preload("BastionServer").
-			Preload("NodePools").
-			Preload("NodePools.Labels").
-			Preload("NodePools.Annotations").
-			Preload("NodePools.Taints").
-			Preload("NodePools.Servers").
-			Preload("Metadata").
-			First(&cluster, "id = ?", cluster.ID).Error; err != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(cluster, cfg))
+		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
 	}
 }
 
@@ -1310,34 +1396,35 @@ func ClearClusterKubeconfig(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		cluster.EncryptedKubeconfig = ""
-		cluster.KubeIV = ""
-		cluster.KubeTag = ""
+		res := db.Model(&models.Cluster{}).
+			Where("id = ? AND organization_id = ?", clusterID, orgID).
+			Updates(map[string]any{
+				colClusterEncryptedKubeconfig: "",
+				colClusterKubeIV:              "",
+				colClusterKubeTag:             "",
+				colClusterStatus:              models.ClusterStatusPrePending,
+				colClusterLastError:           "",
+			})
+		if res.Error != nil {
+			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
+			return
+		}
+		if res.RowsAffected == 0 {
+			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+			return
+		}
 
-		if err := db.Save(&cluster).Error; err != nil {
+		out, err := loadClusterForResponse(db, cluster.ID, orgID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+				return
+			}
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
 
-		_ = markClusterNeedsValidation(db, cluster.ID)
-
-		if err := db.Preload("CaptainDomain").
-			Preload("ControlPlaneRecordSet").
-			Preload("AppsLoadBalancer").
-			Preload("GlueOpsLoadBalancer").
-			Preload("BastionServer").
-			Preload("NodePools").
-			Preload("NodePools.Labels").
-			Preload("NodePools.Annotations").
-			Preload("NodePools.Taints").
-			Preload("NodePools.Servers").
-			Preload("Metadata").
-			First(&cluster, "id = ?", cluster.ID).Error; err != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(cluster, cfg))
+		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
 	}
 }
 
@@ -1416,28 +1503,20 @@ func AttachNodePool(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		_ = markClusterNeedsValidation(db, cluster.ID)
+		_ = markClusterNeedsValidation(db, cluster.ID, orgID)
 
 		// Reload for rich response
-		if err := db.
-			Preload("CaptainDomain").
-			Preload("ControlPlaneRecordSet").
-			Preload("AppsLoadBalancer").
-			Preload("GlueOpsLoadBalancer").
-			Preload("BastionServer").
-			Preload("NodePools").
-			Preload("NodePools.Labels").
-			Preload("NodePools.Annotations").
-			Preload("NodePools.Taints").
-			Preload("NodePools.Servers").
-			Preload("Metadata").
-			First(&cluster, "id = ?", cluster.ID).Error; err != nil {
-
+		out, err := loadClusterForResponse(db, cluster.ID, orgID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+				return
+			}
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
 
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(cluster, cfg))
+		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
 	}
 }
 
@@ -1512,27 +1591,19 @@ func DetachNodePool(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		_ = markClusterNeedsValidation(db, cluster.ID)
+		_ = markClusterNeedsValidation(db, cluster.ID, orgID)
 
-		if err := db.
-			Preload("CaptainDomain").
-			Preload("ControlPlaneRecordSet").
-			Preload("AppsLoadBalancer").
-			Preload("GlueOpsLoadBalancer").
-			Preload("BastionServer").
-			Preload("NodePools").
-			Preload("NodePools.Labels").
-			Preload("NodePools.Annotations").
-			Preload("NodePools.Taints").
-			Preload("NodePools.Servers").
-			Preload("Metadata").
-			First(&cluster, "id = ?", cluster.ID).Error; err != nil {
-
+		out, err := loadClusterForResponse(db, cluster.ID, orgID)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+				return
+			}
 			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
 			return
 		}
 
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(cluster, cfg))
+		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
 	}
 }
 
@@ -1734,9 +1805,39 @@ func GenerateFormattedToken() (string, error) {
 	return fmt.Sprintf("%s.%s", part1, part2), nil
 }
 
-func markClusterNeedsValidation(db *gorm.DB, clusterID uuid.UUID) error {
-	return db.Model(&models.Cluster{}).Where("id = ?", clusterID).Updates(map[string]any{
-		"status":     models.ClusterStatusPrePending,
-		"last_error": "",
-	}).Error
+// loadClusterForResponse reads a cluster into a fresh struct for rendering.
+//
+// It must not reuse a struct a handler has already written through. Re-scanning
+// a row into a struct whose pointer field is already set does not clear that
+// field when the column is NULL, so a reused struct can report an attachment
+// that no longer exists.
+func loadClusterForResponse(db *gorm.DB, clusterID, orgID uuid.UUID) (models.Cluster, error) {
+	var c models.Cluster
+	err := db.
+		Preload("CaptainDomain").
+		Preload("ControlPlaneRecordSet").
+		Preload("AppsLoadBalancer").
+		Preload("GlueOpsLoadBalancer").
+		Preload("BastionServer").
+		Preload("NodePools").
+		Preload("NodePools.Labels").
+		Preload("NodePools.Annotations").
+		Preload("NodePools.Taints").
+		Preload("NodePools.Servers").
+		Preload("Metadata").
+		Where("id = ? AND organization_id = ?", clusterID, orgID).
+		First(&c).Error
+	return c, err
+}
+
+// markClusterNeedsValidation is for callers that change a cluster's shape
+// without writing the cluster row itself; handlers that do write the row fold
+// these two columns into that write so the change is atomic.
+func markClusterNeedsValidation(db *gorm.DB, clusterID, orgID uuid.UUID) error {
+	return db.Model(&models.Cluster{}).
+		Where("id = ? AND organization_id = ?", clusterID, orgID).
+		Updates(map[string]any{
+			colClusterStatus:    models.ClusterStatusPrePending,
+			colClusterLastError: "",
+		}).Error
 }

--- a/internal/handlers/clusters.go
+++ b/internal/handlers/clusters.go
@@ -344,10 +344,7 @@ func UpdateCluster(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 		// Apply only provided fields. Keys are hardcoded, never taken from the
 		// request: a map keyed from request JSON would make organization_id and
 		// the kubeadm credentials writable by any caller.
-		updates := map[string]any{
-			colClusterStatus:    models.ClusterStatusPrePending,
-			colClusterLastError: "",
-		}
+		updates := map[string]any{}
 		if in.Name != nil {
 			updates[colClusterName] = *in.Name
 		}
@@ -364,30 +361,8 @@ func UpdateCluster(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			updates[colClusterDockerTag] = *in.DockerTag
 		}
 
-		res := db.Model(&models.Cluster{}).
-			Where("id = ? AND organization_id = ?", clusterID, orgID).
-			Updates(updates)
-		if res.Error != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-		if res.RowsAffected == 0 {
-			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-			return
-		}
-
-		// Preload for a rich response
-		out, err := loadClusterForResponse(db, cluster.ID, orgID)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-				return
-			}
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
+		out, err := writeClusterColumns(db, clusterID, orgID, updates)
+		respondCluster(w, cfg, out, err)
 	}
 }
 
@@ -500,34 +475,10 @@ func AttachCaptainDomain(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		res := db.Model(&models.Cluster{}).
-			Where("id = ? AND organization_id = ?", clusterID, orgID).
-			Updates(map[string]any{
-				colClusterCaptainDomainID: domain.ID,
-				colClusterStatus:          models.ClusterStatusPrePending,
-				colClusterLastError:       "",
-			})
-		if res.Error != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-		if res.RowsAffected == 0 {
-			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-			return
-		}
-
-		// Preload domain for response
-		out, err := loadClusterForResponse(db, cluster.ID, orgID)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-				return
-			}
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
+		out, err := writeClusterColumns(db, clusterID, orgID, map[string]any{
+			colClusterCaptainDomainID: domain.ID,
+		})
+		respondCluster(w, cfg, out, err)
 	}
 }
 
@@ -574,33 +525,10 @@ func DetachCaptainDomain(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		res := db.Model(&models.Cluster{}).
-			Where("id = ? AND organization_id = ?", clusterID, orgID).
-			Updates(map[string]any{
-				colClusterCaptainDomainID: nil,
-				colClusterStatus:          models.ClusterStatusPrePending,
-				colClusterLastError:       "",
-			})
-		if res.Error != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-		if res.RowsAffected == 0 {
-			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-			return
-		}
-
-		out, err := loadClusterForResponse(db, cluster.ID, orgID)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-				return
-			}
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
+		out, err := writeClusterColumns(db, clusterID, orgID, map[string]any{
+			colClusterCaptainDomainID: nil,
+		})
+		respondCluster(w, cfg, out, err)
 	}
 }
 
@@ -669,33 +597,10 @@ func AttachControlPlaneRecordSet(db *gorm.DB, cfg config.Config) http.HandlerFun
 			return
 		}
 
-		res := db.Model(&models.Cluster{}).
-			Where("id = ? AND organization_id = ?", clusterID, orgID).
-			Updates(map[string]any{
-				colClusterControlPlaneRecordSetID: rs.ID,
-				colClusterStatus:                  models.ClusterStatusPrePending,
-				colClusterLastError:               "",
-			})
-		if res.Error != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-		if res.RowsAffected == 0 {
-			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-			return
-		}
-
-		out, err := loadClusterForResponse(db, cluster.ID, orgID)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-				return
-			}
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
+		out, err := writeClusterColumns(db, clusterID, orgID, map[string]any{
+			colClusterControlPlaneRecordSetID: rs.ID,
+		})
+		respondCluster(w, cfg, out, err)
 	}
 }
 
@@ -742,33 +647,10 @@ func DetachControlPlaneRecordSet(db *gorm.DB, cfg config.Config) http.HandlerFun
 			return
 		}
 
-		res := db.Model(&models.Cluster{}).
-			Where("id = ? AND organization_id = ?", clusterID, orgID).
-			Updates(map[string]any{
-				colClusterControlPlaneRecordSetID: nil,
-				colClusterStatus:                  models.ClusterStatusPrePending,
-				colClusterLastError:               "",
-			})
-		if res.Error != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-		if res.RowsAffected == 0 {
-			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-			return
-		}
-
-		out, err := loadClusterForResponse(db, cluster.ID, orgID)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-				return
-			}
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
+		out, err := writeClusterColumns(db, clusterID, orgID, map[string]any{
+			colClusterControlPlaneRecordSetID: nil,
+		})
+		respondCluster(w, cfg, out, err)
 	}
 }
 
@@ -833,33 +715,10 @@ func AttachAppsLoadBalancer(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		res := db.Model(&models.Cluster{}).
-			Where("id = ? AND organization_id = ?", clusterID, orgID).
-			Updates(map[string]any{
-				colClusterAppsLoadBalancerID: lb.ID,
-				colClusterStatus:             models.ClusterStatusPrePending,
-				colClusterLastError:          "",
-			})
-		if res.Error != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-		if res.RowsAffected == 0 {
-			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-			return
-		}
-
-		out, err := loadClusterForResponse(db, cluster.ID, orgID)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-				return
-			}
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
+		out, err := writeClusterColumns(db, clusterID, orgID, map[string]any{
+			colClusterAppsLoadBalancerID: lb.ID,
+		})
+		respondCluster(w, cfg, out, err)
 	}
 }
 
@@ -906,33 +765,10 @@ func DetachAppsLoadBalancer(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		res := db.Model(&models.Cluster{}).
-			Where("id = ? AND organization_id = ?", clusterID, orgID).
-			Updates(map[string]any{
-				colClusterAppsLoadBalancerID: nil,
-				colClusterStatus:             models.ClusterStatusPrePending,
-				colClusterLastError:          "",
-			})
-		if res.Error != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-		if res.RowsAffected == 0 {
-			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-			return
-		}
-
-		out, err := loadClusterForResponse(db, cluster.ID, orgID)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-				return
-			}
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
+		out, err := writeClusterColumns(db, clusterID, orgID, map[string]any{
+			colClusterAppsLoadBalancerID: nil,
+		})
+		respondCluster(w, cfg, out, err)
 	}
 }
 
@@ -997,33 +833,10 @@ func AttachGlueOpsLoadBalancer(db *gorm.DB, cfg config.Config) http.HandlerFunc 
 			return
 		}
 
-		res := db.Model(&models.Cluster{}).
-			Where("id = ? AND organization_id = ?", clusterID, orgID).
-			Updates(map[string]any{
-				colClusterGlueOpsLoadBalancerID: lb.ID,
-				colClusterStatus:                models.ClusterStatusPrePending,
-				colClusterLastError:             "",
-			})
-		if res.Error != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-		if res.RowsAffected == 0 {
-			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-			return
-		}
-
-		out, err := loadClusterForResponse(db, cluster.ID, orgID)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-				return
-			}
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
+		out, err := writeClusterColumns(db, clusterID, orgID, map[string]any{
+			colClusterGlueOpsLoadBalancerID: lb.ID,
+		})
+		respondCluster(w, cfg, out, err)
 	}
 }
 
@@ -1070,33 +883,10 @@ func DetachGlueOpsLoadBalancer(db *gorm.DB, cfg config.Config) http.HandlerFunc 
 			return
 		}
 
-		res := db.Model(&models.Cluster{}).
-			Where("id = ? AND organization_id = ?", clusterID, orgID).
-			Updates(map[string]any{
-				colClusterGlueOpsLoadBalancerID: nil,
-				colClusterStatus:                models.ClusterStatusPrePending,
-				colClusterLastError:             "",
-			})
-		if res.Error != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-		if res.RowsAffected == 0 {
-			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-			return
-		}
-
-		out, err := loadClusterForResponse(db, cluster.ID, orgID)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-				return
-			}
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
+		out, err := writeClusterColumns(db, clusterID, orgID, map[string]any{
+			colClusterGlueOpsLoadBalancerID: nil,
+		})
+		respondCluster(w, cfg, out, err)
 	}
 }
 
@@ -1161,33 +951,10 @@ func AttachBastionServer(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		res := db.Model(&models.Cluster{}).
-			Where("id = ? AND organization_id = ?", clusterID, orgID).
-			Updates(map[string]any{
-				colClusterBastionServerID: server.ID,
-				colClusterStatus:          models.ClusterStatusPrePending,
-				colClusterLastError:       "",
-			})
-		if res.Error != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-		if res.RowsAffected == 0 {
-			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-			return
-		}
-
-		out, err := loadClusterForResponse(db, cluster.ID, orgID)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-				return
-			}
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
+		out, err := writeClusterColumns(db, clusterID, orgID, map[string]any{
+			colClusterBastionServerID: server.ID,
+		})
+		respondCluster(w, cfg, out, err)
 	}
 }
 
@@ -1234,33 +1001,10 @@ func DetachBastionServer(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		res := db.Model(&models.Cluster{}).
-			Where("id = ? AND organization_id = ?", clusterID, orgID).
-			Updates(map[string]any{
-				colClusterBastionServerID: nil,
-				colClusterStatus:          models.ClusterStatusPrePending,
-				colClusterLastError:       "",
-			})
-		if res.Error != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-		if res.RowsAffected == 0 {
-			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-			return
-		}
-
-		out, err := loadClusterForResponse(db, cluster.ID, orgID)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-				return
-			}
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
+		out, err := writeClusterColumns(db, clusterID, orgID, map[string]any{
+			colClusterBastionServerID: nil,
+		})
+		respondCluster(w, cfg, out, err)
 	}
 }
 
@@ -1321,35 +1065,12 @@ func SetClusterKubeconfig(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		res := db.Model(&models.Cluster{}).
-			Where("id = ? AND organization_id = ?", clusterID, orgID).
-			Updates(map[string]any{
-				colClusterEncryptedKubeconfig: ct,
-				colClusterKubeIV:              iv,
-				colClusterKubeTag:             tag,
-				colClusterStatus:              models.ClusterStatusPrePending,
-				colClusterLastError:           "",
-			})
-		if res.Error != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-		if res.RowsAffected == 0 {
-			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-			return
-		}
-
-		out, err := loadClusterForResponse(db, cluster.ID, orgID)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-				return
-			}
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
+		out, err := writeClusterColumns(db, clusterID, orgID, map[string]any{
+			colClusterEncryptedKubeconfig: ct,
+			colClusterKubeIV:              iv,
+			colClusterKubeTag:             tag,
+		})
+		respondCluster(w, cfg, out, err)
 	}
 }
 
@@ -1396,35 +1117,12 @@ func ClearClusterKubeconfig(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 			return
 		}
 
-		res := db.Model(&models.Cluster{}).
-			Where("id = ? AND organization_id = ?", clusterID, orgID).
-			Updates(map[string]any{
-				colClusterEncryptedKubeconfig: "",
-				colClusterKubeIV:              "",
-				colClusterKubeTag:             "",
-				colClusterStatus:              models.ClusterStatusPrePending,
-				colClusterLastError:           "",
-			})
-		if res.Error != nil {
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-		if res.RowsAffected == 0 {
-			utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-			return
-		}
-
-		out, err := loadClusterForResponse(db, cluster.ID, orgID)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-				return
-			}
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
+		out, err := writeClusterColumns(db, clusterID, orgID, map[string]any{
+			colClusterEncryptedKubeconfig: "",
+			colClusterKubeIV:              "",
+			colClusterKubeTag:             "",
+		})
+		respondCluster(w, cfg, out, err)
 	}
 }
 
@@ -1505,18 +1203,8 @@ func AttachNodePool(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 
 		_ = markClusterNeedsValidation(db, cluster.ID, orgID)
 
-		// Reload for rich response
 		out, err := loadClusterForResponse(db, cluster.ID, orgID)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-				return
-			}
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
+		respondCluster(w, cfg, out, err)
 	}
 }
 
@@ -1594,16 +1282,7 @@ func DetachNodePool(db *gorm.DB, cfg config.Config) http.HandlerFunc {
 		_ = markClusterNeedsValidation(db, cluster.ID, orgID)
 
 		out, err := loadClusterForResponse(db, cluster.ID, orgID)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
-				return
-			}
-			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
-			return
-		}
-
-		utils.WriteJSON(w, http.StatusOK, clusterToDTO(out, cfg))
+		respondCluster(w, cfg, out, err)
 	}
 }
 
@@ -1828,6 +1507,54 @@ func loadClusterForResponse(db *gorm.DB, clusterID, orgID uuid.UUID) (models.Clu
 		Where("id = ? AND organization_id = ?", clusterID, orgID).
 		First(&c).Error
 	return c, err
+}
+
+// writeClusterColumns updates the columns a handler owns on one org-scoped
+// cluster, then reloads it for rendering.
+//
+// It sets status and last_error itself rather than trusting each caller to
+// remember them. Every change to a cluster's shape has to re-arm validation,
+// and that invariant held by convention across a dozen hand-written maps is one
+// omission away from a cluster that silently never gets revalidated.
+//
+// cols carries only the columns the caller owns, never the whole row: a
+// whole-row write replays every column from a snapshot taken before the read,
+// so two concurrent handlers undo each other. Keys must be column names from
+// the colCluster* constants -- see the comment on those for why a Go field name
+// silently writes nothing.
+//
+// A write matching no rows is ErrRecordNotFound, not success. The row was
+// deleted between the caller's read and this write, and the caller must not
+// report a change it did not make; db.Save used to answer that case with an
+// INSERT that resurrected the row with every stale foreign key restored.
+func writeClusterColumns(db *gorm.DB, clusterID, orgID uuid.UUID, cols map[string]any) (models.Cluster, error) {
+	cols[colClusterStatus] = models.ClusterStatusPrePending
+	cols[colClusterLastError] = ""
+
+	res := db.Model(&models.Cluster{}).
+		Where("id = ? AND organization_id = ?", clusterID, orgID).
+		Updates(cols)
+	if res.Error != nil {
+		return models.Cluster{}, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return models.Cluster{}, gorm.ErrRecordNotFound
+	}
+
+	return loadClusterForResponse(db, clusterID, orgID)
+}
+
+// respondCluster writes the response for a handler that has finished its work:
+// a missing row is 404, any other error is 500.
+func respondCluster(w http.ResponseWriter, cfg config.Config, c models.Cluster, err error) {
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		utils.WriteError(w, http.StatusNotFound, "not_found", "cluster not found")
+	case err != nil:
+		utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
+	default:
+		utils.WriteJSON(w, http.StatusOK, clusterToDTO(c, cfg))
+	}
 }
 
 // markClusterNeedsValidation is for callers that change a cluster's shape

--- a/internal/testutil/pgtest/pgtest.go
+++ b/internal/testutil/pgtest/pgtest.go
@@ -3,6 +3,9 @@ package pgtest
 import (
 	"fmt"
 	"log"
+	"net"
+	"os"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -13,6 +16,34 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
+
+// EnvPort lets a caller pin the embedded Postgres port. When unset, a free
+// port is chosen at runtime: a fixed port collides with anything else already
+// listening (another checkout, a local Postgres, a stray container) and turns
+// an unrelated process into an unexplained test failure.
+const EnvPort = "AUTOGLUE_TEST_PG_PORT"
+
+// listenPort returns the port embedded Postgres should bind.
+func listenPort() uint32 {
+	if v := os.Getenv(EnvPort); v != "" {
+		p, err := strconv.ParseUint(v, 10, 16)
+		if err != nil || p == 0 {
+			log.Printf("pgtest: ignoring invalid %s=%q, selecting a free port", EnvPort, v)
+		} else {
+			return uint32(p)
+		}
+	}
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		// Nothing better to fall back to; Start will report the real failure.
+		log.Printf("pgtest: could not reserve a free port (%v), falling back to 55432", err)
+		return 55432
+	}
+	port := uint32(l.Addr().(*net.TCPAddr).Port)
+	_ = l.Close()
+	return port
+}
 
 var (
 	once    sync.Once
@@ -25,7 +56,7 @@ var (
 // initDB is called once via sync.Once. It starts embedded Postgres,
 // opens a GORM connection and runs the same migrations as NewRuntime.
 func initDB() {
-	const port uint32 = 55432
+	port := listenPort()
 
 	cfg := embeddedpostgres.
 		DefaultConfig().
@@ -55,7 +86,9 @@ func initDB() {
 		return
 	}
 
-	// Use the same model list as app.NewRuntime so schema matches prod
+	// Keep this list identical to app.NewRuntime, in the same order, so tests
+	// migrate the same schema production does. Anything missing here surfaces
+	// as an unrelated-looking failure in whichever test first Preloads it.
 	if err := db.Run(
 		dbConn,
 		&models.Job{},
@@ -75,10 +108,14 @@ func initDB() {
 		&models.Label{},
 		&models.Annotation{},
 		&models.NodePool{},
-		&models.Cluster{},
 		&models.Credential{},
 		&models.Domain{},
 		&models.RecordSet{},
+		&models.LoadBalancer{},
+		&models.Cluster{},
+		&models.Action{},
+		&models.ClusterRun{},
+		&models.ClusterMetadata{},
 	); err != nil {
 		initErr = fmt.Errorf("migrate: %w", err)
 		return


### PR DESCRIPTION
## Problem

`tofu destroy` intermittently fails with:

```
DELETE /dns/records/{id} -> 500
update or delete on table "record_sets" violates foreign key constraint
"fk_clusters_control_plane_record_set" on table "clusters" (SQLSTATE 23503)
```

([failing run](https://github.com/GlueOps/opentofu-module-GlueKube-AWS/actions/runs/30430150562/job/90505275052))

OpenTofu destroys a cluster's attachments in parallel, so several detach handlers hit the same row at once. Each loaded the whole cluster, changed one field, and called `db.Save` — which writes all 21 columns from the snapshot taken before the read. The last writer replayed stale values over the others, restoring a foreign key a concurrent detach had just cleared. Deleting the referenced row then failed.

Reproduced at ~28% under concurrency; never serially.

## Fix

All 13 cluster writes in `clusters.go` now update only their own columns, which makes them commutative.

Three consequences worth reviewing:

- **Column names are constants, with a schema test.** Not ceremony: GORM resolves an association field name (`ControlPlaneRecordSet`, one deleted `ID` from `ControlPlaneRecordSetID`) to a field with no column, drops the assignment, and returns 200 — reintroducing this exact bug silently.
- **Responses render from a freshly loaded struct.** Re-scanning into a struct already written through does not clear a pointer field when the column is NULL, so the old code could report an attachment that no longer existed.
- **A write matching no rows is now 404, not 200.** `db.Save` fell back to an INSERT, so a detach racing a cluster delete recreated the row with every stale foreign key restored.

`markClusterNeedsValidation` is folded into each write (one statement instead of two) and is now org-scoped; it was not. `servers.go` deliberately keeps `db.Save` — `Server.BeforeSave` enforces that a bastion has a public IP, and GORM dispatches hooks off the destination value, so a map update would bypass it.

## Verification

The regression test drives the interleaving from a GORM callback rather than racing goroutines, so it is deterministic. Reverting one handler to `db.Save` fails it, and only it:

```
--- FAIL: .../control_plane_record_set
    captain_domain_id: the concurrent write was clobbered --
    the handler replayed a stale value ("f16d7522-...")
```

The behaviour tests in the second commit were written against the unfixed code and pass unchanged afterwards, which is the evidence this is a refactor rather than a rewrite.

The first commit exists because the repo ran no tests: `go test ./...` cannot compile on a fresh clone (five packages embed gitignored generated artifacts), and `pgtest` hardcoded a port and migrated 21 of 25 models.

## Out of scope

Filed separately rather than bundled: `bg/dns.go` row resurrection, the provider's `Delete` implementations not tolerating 404, and mapping `23503` to 409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)