### PR TITLE
fix(docker): install the binary onto PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,17 @@ RUN apk add --no-cache ca-certificates tzdata postgresql17-client \
  && addgroup -S app && adduser -S app -G app
 
 WORKDIR /app
-COPY --from=builder /src/autoglue /app/autoglue
+
+# Install onto PATH, not just /app. Kubernetes `command:` replaces ENTRYPOINT
+# rather than appending to it, so a manifest saying `command: ["autoglue",
+# "worker"]` resolves the name through $PATH — and /app is not on it:
+#   /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# Without this the container dies with
+#   exec: "autoglue": executable file not found in $PATH
+COPY --from=builder /src/autoglue /usr/local/bin/autoglue
+
+# Keep the historical path working for anything that hardcodes /app/autoglue.
+RUN ln -s /usr/local/bin/autoglue /app/autoglue
 
 ENV PORT=8080
 EXPOSE 8080
@@ -52,5 +62,8 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
 
 # One image, two roles. Override the command with `worker` to run background
 # jobs; `serve` never processes them.
-ENTRYPOINT ["/app/autoglue"]
+#
+# Works as `args: ["worker"]` (ENTRYPOINT is kept) and as
+# `command: ["autoglue", "worker"]` (ENTRYPOINT is replaced, name found on PATH).
+ENTRYPOINT ["autoglue"]
 CMD ["serve"]


### PR DESCRIPTION
## Problem

Containers started with `command: ["autoglue", ...]` fail to start:

```
exec: "autoglue": executable file not found in $PATH
```

The binary was only ever placed at `/app/autoglue`, and `/app` is **not** on Alpine's `PATH`:

```
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

Kubernetes `command:` **replaces** ENTRYPOINT rather than appending to it, so the name is resolved through `$PATH` and never found. This bites specifically now that the image has two roles (`serve` / `worker`), because that's what pushed manifests toward spelling the command out.

Reproduced on the published image before changing anything:

```
$ docker run --rm --entrypoint autoglue ghcr.io/glueops/autoglue:v0.11.0 version
exec: "autoglue": executable file not found in $PATH
```

## Fix

- Install to `/usr/local/bin/autoglue`, which is on `PATH`.
- Symlink `/app/autoglue` at it, so anything hardcoding the old absolute path keeps working.
- `ENTRYPOINT ["autoglue"]`, which resolves either way.

## Verification

Built the image and exercised every invocation form:

| Invocation | Result |
| --- | --- |
| `docker run <img> version` (ENTRYPOINT + CMD) | ✅ |
| `docker run --entrypoint autoglue <img> version` (k8s `command:`) | ✅ — was the failure |
| `docker run --entrypoint /app/autoglue <img> version` (legacy path) | ✅ |
| `docker run <img> worker` (args override) | ✅ |

`command -v autoglue` → `/usr/local/bin/autoglue`. Both `serve` and `worker` are present in the command list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)