### PR TITLE
feat(jobs): stream bastion and cluster action output, fix bastion concurrency

### DIFF
--- a/internal/api/mount_cluster_routes.go
+++ b/internal/api/mount_cluster_routes.go
@@ -48,6 +48,7 @@ func mountClusterRoutes(r chi.Router, db *gorm.DB, cfg config.Config, jobs *bg.C
 
 		c.Get("/{clusterID}/runs", handlers.ListClusterRuns(db))
 		c.Get("/{clusterID}/runs/{runID}", handlers.GetClusterRun(db))
+		c.Get("/{clusterID}/runs/{runID}/logs", handlers.GetClusterRunLogs(db))
 		c.Post("/{clusterID}/actions/{actionID}/runs", handlers.RunClusterAction(db, jobs))
 	})
 }

--- a/internal/api/mount_server_routes.go
+++ b/internal/api/mount_server_routes.go
@@ -14,6 +14,7 @@ func mountServerRoutes(r chi.Router, db *gorm.DB, authOrg func(http.Handler) htt
 		s.Get("/", handlers.ListServers(db))
 		s.Post("/", handlers.CreateServer(db))
 		s.Get("/{id}", handlers.GetServer(db))
+		s.Get("/{id}/logs", handlers.GetServerLogs(db))
 		s.Patch("/{id}", handlers.UpdateServer(db))
 		s.Delete("/{id}", handlers.DeleteServer(db))
 		s.Post("/{id}/reset-hostkey", handlers.ResetServerHostKey(db))

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -51,6 +51,7 @@ func NewRuntime() *Runtime {
 		&models.Action{},
 		&models.ClusterRun{},
 		&models.ClusterMetadata{},
+		&models.JobLog{},
 	)
 
 	if err != nil {

--- a/internal/bg/bastion.go
+++ b/internal/bg/bastion.go
@@ -3,6 +3,7 @@ package bg
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -13,7 +14,9 @@ import (
 	"github.com/glueops/autoglue/internal/models"
 	"github.com/glueops/autoglue/internal/utils"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/crypto/ssh"
 	"gorm.io/gorm"
@@ -22,12 +25,44 @@ import (
 
 // ----- Public types -----
 
-type BastionBootstrapArgs struct{}
+// BastionSweepArgs drives the periodic claim tick. It does no SSH work itself:
+// it moves servers from pending to provisioning and fans out one bootstrap job
+// per server.
+type BastionSweepArgs struct{}
+
+func (BastionSweepArgs) Kind() string { return "bastion_sweep" }
+
+func (BastionSweepArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{Queue: QueueMaintenance, MaxAttempts: 2}
+}
+
+// BastionBootstrapArgs bootstraps exactly one bastion.
+//
+// One job per server, rather than one job per tick, because the claim flips a
+// server to provisioning up front: if a single job owned every claimed server
+// and then hit its timeout, the ones it never reached would sit in
+// provisioning forever with nothing to reclaim them.
+type BastionBootstrapArgs struct {
+	ServerID uuid.UUID `json:"server_id"`
+}
 
 func (BastionBootstrapArgs) Kind() string { return "bootstrap_bastion" }
 
 func (BastionBootstrapArgs) InsertOpts() river.InsertOpts {
-	return river.InsertOpts{Queue: QueueClusters, MaxAttempts: 3}
+	return river.InsertOpts{
+		Queue:       QueueClusters,
+		MaxAttempts: 1,
+		// Never bootstrap the same host twice concurrently: the remote script
+		// takes apt/dpkg locks and two runs would fight over them.
+		UniqueOpts: river.UniqueOpts{
+			ByArgs: true,
+			ByState: []rivertype.JobState{
+				rivertype.JobStateAvailable, rivertype.JobStateScheduled,
+				rivertype.JobStateRunning, rivertype.JobStateRetryable,
+				rivertype.JobStatePending,
+			},
+		},
+	}
 }
 
 type BastionBootstrapFailure struct {
@@ -36,27 +71,105 @@ type BastionBootstrapFailure struct {
 	Reason string    `json:"reason"`
 }
 
-type BastionBootstrapResult struct {
-	Status       string                    `json:"status"`
-	Processed    int                       `json:"processed"`
-	Ready        int                       `json:"ready"`
-	Failed       int                       `json:"failed"`
-	ElapsedMs    int                       `json:"elapsed_ms"`
-	FailedServer []uuid.UUID               `json:"failed_server_ids"`
-	Failures     []BastionBootstrapFailure `json:"failures"`
+type BastionSweepResult struct {
+	Status     string      `json:"status"`
+	Claimed    int         `json:"claimed"`
+	Dispatched int         `json:"dispatched"`
+	ServerIDs  []uuid.UUID `json:"server_ids"`
 }
 
-// ----- Worker -----
+type BastionBootstrapResult struct {
+	Status    string    `json:"status"`
+	ServerID  uuid.UUID `json:"server_id"`
+	ElapsedMs int       `json:"elapsed_ms"`
+}
+
+// ----- Sweep (claim + dispatch) -----
+
+type BastionSweepWorker struct {
+	river.WorkerDefaults[BastionSweepArgs]
+	db *gorm.DB
+}
+
+func (w *BastionSweepWorker) Timeout(*river.Job[BastionSweepArgs]) time.Duration {
+	return time.Minute
+}
+
+func (w *BastionSweepWorker) Work(ctx context.Context, j *river.Job[BastionSweepArgs]) error {
+	db := w.db
+
+	// Atomically claim pending bastion servers using SELECT FOR UPDATE SKIP LOCKED
+	// so that concurrent sweeps never claim the same server. `pending` is the
+	// enqueue signal; flipping to `provisioning` is what removes a server from
+	// this tick's queue.
+	var claimedIDs []uuid.UUID
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.
+			Model(&models.Server{}).
+			Where("role = ? AND status = ?", "bastion", "pending").
+			Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
+			Pluck("id", &claimedIDs).Error; err != nil {
+			return err
+		}
+		if len(claimedIDs) == 0 {
+			return nil
+		}
+		return tx.Model(&models.Server{}).
+			Where("id IN ?", claimedIDs).
+			Updates(map[string]any{
+				"status":     "provisioning",
+				"updated_at": time.Now(),
+			}).Error
+	}); err != nil {
+		log.Printf("[bastion] level=ERROR job=%d step=claim_servers msg=%q", j.ID, err)
+		return err
+	}
+
+	if len(claimedIDs) == 0 {
+		return nil
+	}
+
+	client := river.ClientFromContext[pgx.Tx](ctx)
+
+	dispatched := 0
+	for _, id := range claimedIDs {
+		if _, err := client.Insert(ctx, BastionBootstrapArgs{ServerID: id}, nil); err != nil {
+			// Hand the server back so a later tick retries it, rather than
+			// leaving it stranded in provisioning.
+			log.Error().Err(err).Str("server_id", id.String()).
+				Msg("[bastion] could not dispatch bootstrap; returning server to pending")
+			_ = setServerStatus(db, id, "pending")
+			continue
+		}
+		dispatched++
+	}
+
+	log.Info().Int("claimed", len(claimedIDs)).Int("dispatched", dispatched).
+		Msg("[bastion] sweep dispatched bootstrap jobs")
+
+	if err := river.RecordOutput(ctx, BastionSweepResult{
+		Status:     "ok",
+		Claimed:    len(claimedIDs),
+		Dispatched: dispatched,
+		ServerIDs:  claimedIDs,
+	}); err != nil {
+		log.Warn().Err(err).Msg("[bastion] could not record sweep output")
+	}
+	return nil
+}
+
+// ----- Bootstrap (one server) -----
 
 type BastionBootstrapWorker struct {
 	river.WorkerDefaults[BastionBootstrapArgs]
 	db *gorm.DB
 }
 
-// Timeout is generous because a single tick SSHes into every pending bastion in
-// series, each with its own 8 minute budget.
+// Timeout bounds a single host. The remote script installs packages over a
+// network that may be slow, so this is generous, but it is per server rather
+// than per tick.
 func (w *BastionBootstrapWorker) Timeout(*river.Job[BastionBootstrapArgs]) time.Duration {
-	return time.Hour
+	return 30 * time.Minute
 }
 
 func (w *BastionBootstrapWorker) Work(ctx context.Context, j *river.Job[BastionBootstrapArgs]) error {
@@ -64,146 +177,84 @@ func (w *BastionBootstrapWorker) Work(ctx context.Context, j *river.Job[BastionB
 	jobID := strconv.FormatInt(j.ID, 10)
 	start := time.Now()
 
-	{
-		// Atomically claim pending bastion servers using SELECT FOR UPDATE SKIP LOCKED
-		// so that concurrent worker instances never process the same server simultaneously
-		// (which would cause apt lock conflicts on the remote host).
-		var claimedIDs []uuid.UUID
-		if err := db.Transaction(func(tx *gorm.DB) error {
-			if err := tx.
-				Model(&models.Server{}).
-				Where("role = ? AND status = ?", "bastion", "pending").
-				Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
-				Pluck("id", &claimedIDs).Error; err != nil {
-				return err
-			}
-			if len(claimedIDs) == 0 {
-				return nil
-			}
-			return tx.Model(&models.Server{}).
-				Where("id IN ?", claimedIDs).
-				Updates(map[string]any{
-					"status":     "provisioning",
-					"updated_at": time.Now(),
-				}).Error
-		}); err != nil {
-			log.Printf("[bastion] level=ERROR job=%s step=claim_servers msg=%q", jobID, err)
-			return err
+	var s models.Server
+	if err := db.Preload("SshKey").
+		Where("id = ?", j.Args.ServerID).
+		First(&s).Error; err != nil {
+		// The server was deleted between claim and execution. Nothing to do,
+		// and failing would only requeue a job that can never succeed.
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Warn().Str("server_id", j.Args.ServerID.String()).
+				Msg("[bastion] server vanished before bootstrap")
+			return nil
 		}
+		return err
+	}
 
-		var servers []models.Server
-		if len(claimedIDs) > 0 {
-			if err := db.
-				Preload("SshKey").
-				Where("id IN ?", claimedIDs).
-				Find(&servers).Error; err != nil {
-				log.Printf("[bastion] level=ERROR job=%s step=fetch_servers msg=%q", jobID, err)
-				return err
-			}
-		}
-
-		proc, ok, fail := 0, 0, 0
-		var failedIDs []uuid.UUID
-		var failures []BastionBootstrapFailure
-
-		perHostTimeout := 8 * time.Minute
-
-		for i := range servers {
-			s := &servers[i]
-			proc++
-
-			// 1) Defensive IP check
-			if s.PublicIPAddress == nil || *s.PublicIPAddress == "" {
-				fail++
-				failedIDs = append(failedIDs, s.ID)
-				failures = append(failures, BastionBootstrapFailure{ID: s.ID, Step: "ip_check", Reason: "missing public ip"})
-				logHostErr(jobID, s, "ip_check", fmt.Errorf("missing public ip"))
-				_ = setServerStatus(db, s.ID, "failed")
-				continue
-			}
-
-			// 2) Decrypt private key for org
-			privKey, err := utils.DecryptForOrg(
-				s.OrganizationID,
-				s.SshKey.EncryptedPrivateKey,
-				s.SshKey.PrivateIV,
-				s.SshKey.PrivateTag,
-				db,
-			)
-			if err != nil {
-				fail++
-				failedIDs = append(failedIDs, s.ID)
-				failures = append(failures, BastionBootstrapFailure{ID: s.ID, Step: "decrypt_key", Reason: err.Error()})
-				logHostErr(jobID, s, "decrypt_key", err)
-				_ = setServerStatus(db, s.ID, "failed")
-				continue
-			}
-
-			// 3) SSH + install docker.
-			//
-			// Output streams into job_logs under this server, so a failed
-			// bootstrap can be read back from the API instead of hunting
-			// through worker pod stdout for a truncated tail.
-			host := net.JoinHostPort(*s.PublicIPAddress, "22")
-			sink := NewLogSink(db, j.ID, s.OrganizationID, models.JobLogSubjectServer, s.ID)
-			sink.System(fmt.Sprintf("bootstrapping bastion %s (%s) as %s", s.ID, host, s.SSHUser))
-
-			runCtx, cancel := context.WithTimeout(ctx, perHostTimeout)
-			out, err := sshInstallDockerWithOutput(runCtx, db, s, host, s.SSHUser, []byte(privKey), sink)
-			cancel()
-
-			if err != nil {
-				fail++
-				failedIDs = append(failedIDs, s.ID)
-				failures = append(failures, BastionBootstrapFailure{ID: s.ID, Step: "ssh_install", Reason: err.Error()})
-				sink.System("bootstrap failed: " + err.Error())
-				_ = sink.Close()
-				// include a short tail of output to speed debugging without flooding logs
-				tail := out
-				if len(tail) > 800 {
-					tail = tail[len(tail)-800:]
-				}
-				logHostErr(jobID, s, "ssh_install", fmt.Errorf("%v | tail=%q", err, tail))
-				_ = setServerStatus(db, s.ID, "failed")
-				continue
-			}
-
-			// 4) Mark ready
-			if err := setServerStatus(db, s.ID, "ready"); err != nil {
-				fail++
-				failedIDs = append(failedIDs, s.ID)
-				failures = append(failures, BastionBootstrapFailure{ID: s.ID, Step: "set_ready", Reason: err.Error()})
-				sink.System("failed to mark ready: " + err.Error())
-				_ = sink.Close()
-				logHostErr(jobID, s, "set_ready", err)
-				_ = setServerStatus(db, s.ID, "failed")
-				continue
-			}
-			sink.System("bastion ready")
+	fail := func(step string, err error, sink *LogSink) error {
+		if sink != nil {
+			sink.System("bootstrap failed at " + step + ": " + err.Error())
 			_ = sink.Close()
-			ok++
 		}
+		logHostErr(jobID, &s, step, err)
+		_ = setServerStatus(db, s.ID, "failed")
+		// The failure is recorded on the server row and in job_logs; returning
+		// nil keeps it out of River's retry path, since the operator re-runs by
+		// setting the server back to pending.
+		return nil
+	}
 
-		if err := river.RecordOutput(ctx, BastionBootstrapResult{
-			Status:       "ok",
-			Processed:    proc,
-			Ready:        ok,
-			Failed:       fail,
-			ElapsedMs:    int(time.Since(start).Milliseconds()),
-			FailedServer: failedIDs,
-			Failures:     failures,
-		}); err != nil {
-			log.Warn().Err(err).Msg("[bastion] could not record output")
+	// 1) Defensive IP check
+	if s.PublicIPAddress == nil || *s.PublicIPAddress == "" {
+		return fail("ip_check", fmt.Errorf("missing public ip"), nil)
+	}
+
+	// 2) Decrypt private key for org
+	privKey, err := utils.DecryptForOrg(
+		s.OrganizationID,
+		s.SshKey.EncryptedPrivateKey,
+		s.SshKey.PrivateIV,
+		s.SshKey.PrivateTag,
+		db,
+	)
+	if err != nil {
+		return fail("decrypt_key", err, nil)
+	}
+
+	// 3) SSH + install docker. Output streams into job_logs under this server,
+	// so a failed bootstrap can be read back from the API instead of hunting
+	// through worker pod stdout for a truncated tail.
+	host := net.JoinHostPort(*s.PublicIPAddress, "22")
+	sink := NewLogSink(db, j.ID, s.OrganizationID, models.JobLogSubjectServer, s.ID)
+	sink.System(fmt.Sprintf("bootstrapping bastion %s (%s) as %s", s.ID, host, s.SSHUser))
+
+	out, err := sshInstallDockerWithOutput(ctx, db, &s, host, s.SSHUser, []byte(privKey), sink)
+	if err != nil {
+		tail := out
+		if len(tail) > 800 {
+			tail = tail[len(tail)-800:]
 		}
+		return fail("ssh_install", fmt.Errorf("%v | tail=%q", err, tail), sink)
+	}
 
-		log.Debug().
-			Int("processed", proc).
-			Int("ready", ok).
-			Int("failed", fail).
-			Int64("elapsed_ms", time.Since(start).Milliseconds()).
-			Interface("failures", failures).
-			Interface("failed_server_ids", failedIDs).
-			Msg("[bastion] reconcile tick ok")
+	// 4) Mark ready
+	if err := setServerStatus(db, s.ID, "ready"); err != nil {
+		return fail("set_ready", err, sink)
+	}
+
+	sink.System("bastion ready")
+	_ = sink.Close()
+
+	log.Info().Str("server_id", s.ID.String()).
+		Int64("elapsed_ms", time.Since(start).Milliseconds()).
+		Msg("[bastion] bootstrap ok")
+
+	if err := river.RecordOutput(ctx, BastionBootstrapResult{
+		Status:    "ok",
+		ServerID:  s.ID,
+		ElapsedMs: int(time.Since(start).Milliseconds()),
+	}); err != nil {
+		log.Warn().Err(err).Msg("[bastion] could not record output")
 	}
 	return nil
 }

--- a/internal/bg/bastion.go
+++ b/internal/bg/bastion.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net"
 	"strconv"
 	"strings"
@@ -138,16 +139,25 @@ func (w *BastionBootstrapWorker) Work(ctx context.Context, j *river.Job[BastionB
 				continue
 			}
 
-			// 3) SSH + install docker
+			// 3) SSH + install docker.
+			//
+			// Output streams into job_logs under this server, so a failed
+			// bootstrap can be read back from the API instead of hunting
+			// through worker pod stdout for a truncated tail.
 			host := net.JoinHostPort(*s.PublicIPAddress, "22")
+			sink := NewLogSink(db, j.ID, s.OrganizationID, models.JobLogSubjectServer, s.ID)
+			sink.System(fmt.Sprintf("bootstrapping bastion %s (%s) as %s", s.ID, host, s.SSHUser))
+
 			runCtx, cancel := context.WithTimeout(ctx, perHostTimeout)
-			out, err := sshInstallDockerWithOutput(runCtx, db, s, host, s.SSHUser, []byte(privKey))
+			out, err := sshInstallDockerWithOutput(runCtx, db, s, host, s.SSHUser, []byte(privKey), sink)
 			cancel()
 
 			if err != nil {
 				fail++
 				failedIDs = append(failedIDs, s.ID)
 				failures = append(failures, BastionBootstrapFailure{ID: s.ID, Step: "ssh_install", Reason: err.Error()})
+				sink.System("bootstrap failed: " + err.Error())
+				_ = sink.Close()
 				// include a short tail of output to speed debugging without flooding logs
 				tail := out
 				if len(tail) > 800 {
@@ -163,11 +173,27 @@ func (w *BastionBootstrapWorker) Work(ctx context.Context, j *river.Job[BastionB
 				fail++
 				failedIDs = append(failedIDs, s.ID)
 				failures = append(failures, BastionBootstrapFailure{ID: s.ID, Step: "set_ready", Reason: err.Error()})
+				sink.System("failed to mark ready: " + err.Error())
+				_ = sink.Close()
 				logHostErr(jobID, s, "set_ready", err)
 				_ = setServerStatus(db, s.ID, "failed")
 				continue
 			}
+			sink.System("bastion ready")
+			_ = sink.Close()
 			ok++
+		}
+
+		if err := river.RecordOutput(ctx, BastionBootstrapResult{
+			Status:       "ok",
+			Processed:    proc,
+			Ready:        ok,
+			Failed:       fail,
+			ElapsedMs:    int(time.Since(start).Milliseconds()),
+			FailedServer: failedIDs,
+			Failures:     failures,
+		}); err != nil {
+			log.Warn().Err(err).Msg("[bastion] could not record output")
 		}
 
 		log.Debug().
@@ -215,12 +241,20 @@ func logHostInfo(jobID string, s *models.Server, step, msg string, kv ...any) {
 // ----- SSH & command execution -----
 
 // returns combined stdout/stderr so caller can log it on error
+// sshInstallDockerWithOutput bootstraps a bastion over SSH, streaming the
+// remote script's combined output to sink as it arrives. sink may be nil.
+//
+// The returned string is the trailing logMaxTailBytes only; the full transcript
+// is in job_logs when a sink is supplied. That matters here because the script
+// runs under `set -euxo pipefail`, so the useful evidence is the last `+` trace
+// line before it died — which the old 800-byte stdout tail routinely cut off.
 func sshInstallDockerWithOutput(
 	ctx context.Context,
 	db *gorm.DB,
 	s *models.Server,
 	host, user string,
 	privateKeyPEM []byte,
+	sink io.Writer,
 ) (string, error) {
 	signer, err := ssh.ParsePrivateKey(privateKeyPEM)
 	if err != nil {
@@ -539,9 +573,16 @@ echo "Bootstrap complete. If you were added to the docker group, log out and bac
 	// Send script via stdin to avoid quoting/escaping issues
 	sess.Stdin = strings.NewReader(script)
 
-	// Capture combined stdout+stderr
-	out, runErr := sess.CombinedOutput("bash -s")
-	return string(out), wrapSSHError(runErr, string(out))
+	// Stream combined stdout+stderr rather than buffering to exit, so a
+	// bootstrap that hangs on (say) an apt lock is visible while it hangs.
+	tail := &tailBuffer{max: logMaxTailBytes}
+	var w io.Writer = tail
+	if sink != nil {
+		w = io.MultiWriter(tail, sink)
+	}
+
+	runErr := runSSHStreaming(sess, "bash -s", w)
+	return tail.String(), wrapSSHError(runErr, tail.String())
 }
 
 // annotate common SSH/remote failure modes to speed triage

--- a/internal/bg/cluster_action.go
+++ b/internal/bg/cluster_action.go
@@ -29,6 +29,15 @@ type ClusterActionArgs struct {
 
 func (ClusterActionArgs) Kind() string { return "cluster_action" }
 
+// ClusterActionResult is recorded on the job row via river.RecordOutput, which
+// is River's replacement for the jobs.result column archer used to persist.
+type ClusterActionResult struct {
+	Status    string `json:"status"`
+	Action    string `json:"action"`
+	ClusterID string `json:"cluster_id"`
+	ElapsedMs int    `json:"elapsed_ms"`
+}
+
 func (ClusterActionArgs) InsertOpts() river.InsertOpts {
 	// A cluster action is not safely repeatable: it drives make targets against
 	// a live bastion. Archer ran these with MaxRetries(0); River counts the
@@ -53,6 +62,12 @@ func (w *ClusterActionWorker) Work(ctx context.Context, j *river.Job[ClusterActi
 	start := time.Now()
 	args := j.Args
 	runID := args.RunID
+
+	// Everything this action prints streams into job_logs under the ClusterRun,
+	// so the cluster page can tail it live instead of waiting for the run to
+	// finish (and, on success, losing the output entirely).
+	sink := NewLogSink(db, j.ID, args.OrgID, models.JobLogSubjectClusterRun, runID)
+	defer func() { _ = sink.Close() }()
 
 	{
 		updateRun := func(status string, errMsg string) {
@@ -200,7 +215,8 @@ func (w *ClusterActionWorker) Work(ctx context.Context, j *river.Job[ClusterActi
 		// ---- Step 2: Setup (ping-servers)
 		{
 			runCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
-			out, err := runMakeOnBastion(runCtx, db, &c, "ping-servers")
+			sink.System("running make ping-servers")
+			out, err := runMakeOnBastion(runCtx, db, &c, "ping-servers", sink)
 			cancel()
 			if err != nil {
 				logger.Error().Err(err).Str("output", out).Msg("ping-servers failed")
@@ -219,7 +235,8 @@ func (w *ClusterActionWorker) Work(ctx context.Context, j *river.Job[ClusterActi
 		// ---- Step 3: Bootstrap (parameterized target)
 		{
 			runCtx, cancel := context.WithTimeout(ctx, 60*time.Minute)
-			out, err := runMakeOnBastion(runCtx, db, &c, args.MakeTarget)
+			sink.System("running make " + args.MakeTarget)
+			out, err := runMakeOnBastion(runCtx, db, &c, args.MakeTarget, sink)
 			cancel()
 			if err != nil {
 				logger.Error().Err(err).Str("output", out).Msg("bootstrap target failed")
@@ -235,6 +252,16 @@ func (w *ClusterActionWorker) Work(ctx context.Context, j *river.Job[ClusterActi
 		}
 
 		updateRun("succeeded", "")
+		sink.System("completed")
+
+		if err := river.RecordOutput(ctx, ClusterActionResult{
+			Status:    "ok",
+			Action:    args.Action,
+			ClusterID: c.ID.String(),
+			ElapsedMs: int(time.Since(start).Milliseconds()),
+		}); err != nil {
+			logger.Warn().Err(err).Msg("[cluster_action] could not record output")
+		}
 
 		logger.Info().
 			Str("cluster_id", c.ID.String()).

--- a/internal/bg/dns.go
+++ b/internal/bg/dns.go
@@ -86,6 +86,13 @@ func (w *DNSReconcileWorker) Work(ctx context.Context, job *river.Job[DNSReconci
 		Int("domains", processedDomains).
 		Int("records", processedRecords).
 		Msg("[dns] reconcile tick ok")
+
+	if err := river.RecordOutput(ctx, map[string]any{
+		"domains_processed": processedDomains,
+		"records_processed": processedRecords,
+	}); err != nil {
+		log.Warn().Err(err).Msg("[dns] could not record output")
+	}
 	return nil
 }
 

--- a/internal/bg/job_logs_cleanup.go
+++ b/internal/bg/job_logs_cleanup.go
@@ -1,0 +1,66 @@
+package bg
+
+import (
+	"context"
+	"time"
+
+	"github.com/glueops/autoglue/internal/models"
+	"github.com/riverqueue/river"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+)
+
+type JobLogsCleanupArgs struct {
+	RetainDays int `json:"retain_days,omitempty"`
+}
+
+func (JobLogsCleanupArgs) Kind() string { return "job_logs_cleanup" }
+
+func (JobLogsCleanupArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{Queue: QueueMaintenance, MaxAttempts: 2}
+}
+
+// JobLogsCleanupResult is recorded on the job row via river.RecordOutput.
+type JobLogsCleanupResult struct {
+	Status  string `json:"status"`
+	Deleted int64  `json:"deleted"`
+}
+
+// JobLogsCleanupWorker prunes job_logs. River expires its own job rows, but
+// job_logs is our table and nothing else would ever remove a transcript.
+type JobLogsCleanupWorker struct {
+	river.WorkerDefaults[JobLogsCleanupArgs]
+	db *gorm.DB
+}
+
+func (w *JobLogsCleanupWorker) Timeout(*river.Job[JobLogsCleanupArgs]) time.Duration {
+	return 10 * time.Minute
+}
+
+func (w *JobLogsCleanupWorker) Work(ctx context.Context, job *river.Job[JobLogsCleanupArgs]) error {
+	retainDays := job.Args.RetainDays
+	if retainDays <= 0 {
+		retainDays = jobLogRetainDays()
+	}
+
+	cutoff := time.Now().AddDate(0, 0, -retainDays)
+	res := w.db.Where("created_at < ?", cutoff).Delete(&models.JobLog{})
+	if res.Error != nil {
+		return res.Error
+	}
+
+	if res.RowsAffected > 0 {
+		log.Info().
+			Int64("deleted", res.RowsAffected).
+			Int("retain_days", retainDays).
+			Msg("[job_logs_cleanup] pruned old job output")
+	}
+
+	if err := river.RecordOutput(ctx, JobLogsCleanupResult{
+		Status:  "ok",
+		Deleted: res.RowsAffected,
+	}); err != nil {
+		log.Warn().Err(err).Msg("[job_logs_cleanup] could not record output")
+	}
+	return nil
+}

--- a/internal/bg/logsink.go
+++ b/internal/bg/logsink.go
@@ -1,0 +1,191 @@
+package bg
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/glueops/autoglue/internal/models"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+)
+
+const (
+	// logFlushBytes is the buffered size that forces a write. A `make` target
+	// on a bastion is chatty, and one row per line would be thousands of
+	// INSERTs per run.
+	logFlushBytes = 4 << 10
+
+	// logFlushInterval bounds how stale a tail can be, so a job that goes quiet
+	// mid-step still shows its last output to anyone watching.
+	logFlushInterval = time.Second
+
+	// logMaxTailBytes bounds what a sink keeps in memory to hand back to the
+	// caller as the "output" string. A multi-hour run can emit far more than we
+	// want to hold or put in an error message.
+	logMaxTailBytes = 64 << 10
+)
+
+// LogSink is an io.Writer that appends job output to job_logs.
+//
+// Writes are batched: a flush happens once the buffer reaches logFlushBytes or
+// logFlushInterval elapses, whichever comes first. Close drains whatever is
+// left. It is safe for concurrent use, because stdout and stderr are pumped by
+// separate goroutines into the same sink.
+type LogSink struct {
+	db        *gorm.DB
+	jobID     int64
+	orgID     uuid.UUID
+	subject   string
+	subjectID uuid.UUID
+	stream    string
+
+	mu     sync.Mutex
+	buf    []byte
+	tail   []byte
+	closed bool
+
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// NewLogSink starts a sink writing against one subject. Always Close it, or the
+// final partial chunk is lost and the ticker goroutine leaks.
+func NewLogSink(db *gorm.DB, jobID int64, orgID uuid.UUID, subjectType string, subjectID uuid.UUID) *LogSink {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	s := &LogSink{
+		db:        db,
+		jobID:     jobID,
+		orgID:     orgID,
+		subject:   subjectType,
+		subjectID: subjectID,
+		stream:    models.JobLogStreamStdout,
+		cancel:    cancel,
+		done:      make(chan struct{}),
+	}
+
+	go s.flushLoop(ctx)
+	return s
+}
+
+func (s *LogSink) flushLoop(ctx context.Context) {
+	defer close(s.done)
+
+	t := time.NewTicker(logFlushInterval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			s.flush()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// Write buffers p, flushing if it crosses the size threshold. It never returns
+// an error: losing a log line must not fail the job that produced it.
+func (s *LogSink) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return len(p), nil
+	}
+
+	s.buf = append(s.buf, p...)
+
+	s.tail = append(s.tail, p...)
+	if len(s.tail) > logMaxTailBytes {
+		s.tail = s.tail[len(s.tail)-logMaxTailBytes:]
+	}
+
+	over := len(s.buf) >= logFlushBytes
+	s.mu.Unlock()
+
+	if over {
+		s.flush()
+	}
+	return len(p), nil
+}
+
+// System records a line from autoglue itself rather than the remote host, so a
+// reader can tell "starting make bootstrap" from the command's own output.
+func (s *LogSink) System(msg string) {
+	s.append(models.JobLogStreamSystem, []byte(msg+"\n"))
+}
+
+func (s *LogSink) flush() {
+	s.mu.Lock()
+	if len(s.buf) == 0 {
+		s.mu.Unlock()
+		return
+	}
+	chunk := string(s.buf)
+	s.buf = s.buf[:0]
+	s.mu.Unlock()
+
+	s.append(s.stream, []byte(chunk))
+}
+
+func (s *LogSink) append(stream string, chunk []byte) {
+	if len(chunk) == 0 {
+		return
+	}
+
+	row := models.JobLog{
+		JobID:          s.jobID,
+		OrganizationID: s.orgID,
+		SubjectType:    s.subject,
+		SubjectID:      s.subjectID,
+		Stream:         stream,
+		Chunk:          string(chunk),
+	}
+
+	if err := s.db.Create(&row).Error; err != nil {
+		// Deliberately non-fatal: the job's own work matters more than its
+		// narration, and this is already on an error path often enough.
+		log.Warn().Err(err).
+			Str("subject_type", s.subject).
+			Str("subject_id", s.subjectID.String()).
+			Msg("[joblog] failed to persist chunk")
+	}
+}
+
+// Tail returns up to logMaxTailBytes of the most recent output. Used for error
+// messages and for the value the old code returned from CombinedOutput.
+func (s *LogSink) Tail() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return string(s.tail)
+}
+
+// Close drains the buffer and stops the flush loop. Safe to call twice.
+func (s *LogSink) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	s.mu.Unlock()
+
+	s.cancel()
+	<-s.done
+
+	// Final drain after the loop has stopped, so nothing races us.
+	s.mu.Lock()
+	chunk := string(s.buf)
+	s.buf = nil
+	s.mu.Unlock()
+
+	if chunk != "" {
+		s.append(s.stream, []byte(chunk))
+	}
+	return nil
+}
+
+var _ io.WriteCloser = (*LogSink)(nil)

--- a/internal/bg/logsink_test.go
+++ b/internal/bg/logsink_test.go
@@ -1,0 +1,58 @@
+package bg
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestTailBufferKeepsOnlyTheEnd(t *testing.T) {
+	tb := &tailBuffer{max: 10}
+
+	for i := 0; i < 100; i++ {
+		if _, err := tb.Write([]byte("0123456789")); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	got := tb.String()
+	if len(got) != 10 {
+		t.Fatalf("tail length = %d, want 10", len(got))
+	}
+	if got != "0123456789" {
+		t.Errorf("tail = %q, want the most recent bytes", got)
+	}
+}
+
+func TestTailBufferUnboundedWhenMaxIsZero(t *testing.T) {
+	tb := &tailBuffer{}
+	for i := 0; i < 5; i++ {
+		_, _ = tb.Write([]byte("ab"))
+	}
+	if got := tb.String(); got != "ababababab" {
+		t.Errorf("tail = %q, want everything retained", got)
+	}
+}
+
+func TestTailBufferConcurrentWritesDoNotRace(t *testing.T) {
+	// stdout and stderr are pumped by separate goroutines into the same writer,
+	// so this is the real access pattern. Run with -race to mean anything.
+	tb := &tailBuffer{max: 1 << 16}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_, _ = tb.Write([]byte(fmt.Sprintf("line-%d-%d\n", n, j)))
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if got := strings.Count(tb.String(), "\n"); got != 800 {
+		t.Errorf("line count = %d, want 800", got)
+	}
+}

--- a/internal/bg/org_key_sweeper.go
+++ b/internal/bg/org_key_sweeper.go
@@ -16,6 +16,14 @@ type OrgKeySweeperArgs struct {
 
 func (OrgKeySweeperArgs) Kind() string { return "org_key_sweeper" }
 
+// OrgKeySweeperResult is recorded on the job row via river.RecordOutput.
+type OrgKeySweeperResult struct {
+	Status           string `json:"status"`
+	MarkedRevoked    int    `json:"marked_revoked"`
+	DeletedEphemeral int    `json:"deleted_ephemeral"`
+	ElapsedMs        int    `json:"elapsed_ms"`
+}
+
 func (OrgKeySweeperArgs) InsertOpts() river.InsertOpts {
 	return river.InsertOpts{Queue: QueueMaintenance, MaxAttempts: 2}
 }
@@ -29,7 +37,8 @@ func (w *OrgKeySweeperWorker) Timeout(*river.Job[OrgKeySweeperArgs]) time.Durati
 	return 5 * time.Minute
 }
 
-func (w *OrgKeySweeperWorker) Work(_ context.Context, job *river.Job[OrgKeySweeperArgs]) error {
+func (w *OrgKeySweeperWorker) Work(ctx context.Context, job *river.Job[OrgKeySweeperArgs]) error {
+	start := time.Now()
 	retentionDays := job.Args.RetentionDays
 	if retentionDays <= 0 {
 		retentionDays = 10
@@ -68,5 +77,13 @@ func (w *OrgKeySweeperWorker) Work(_ context.Context, job *river.Job[OrgKeySweep
 		Int("deleted_ephemeral", deletedEphemeral).
 		Msg("[org_key_sweeper] cleanup tick ok")
 
+	if err := river.RecordOutput(ctx, OrgKeySweeperResult{
+		Status:           "ok",
+		MarkedRevoked:    markedRevoked,
+		DeletedEphemeral: deletedEphemeral,
+		ElapsedMs:        int(time.Since(start).Milliseconds()),
+	}); err != nil {
+		log.Warn().Err(err).Msg("[org_key_sweeper] could not record output")
+	}
 	return nil
 }

--- a/internal/bg/prepare_cluster.go
+++ b/internal/bg/prepare_cluster.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net"
 	"strings"
 	"time"
@@ -266,11 +267,18 @@ func setClusterStatus(db *gorm.DB, id uuid.UUID, status, lastError string) error
 }
 
 // runMakeOnBastion runs `make <target>` from the cluster's directory on the bastion.
+// runMakeOnBastion runs `make <target>` on the cluster's bastion, streaming the
+// combined output to sink as it arrives. sink may be nil, in which case output
+// is still captured for the returned tail but nothing is persisted.
+//
+// The returned string is the trailing logMaxTailBytes of output, not the whole
+// run: the full transcript lives in job_logs when a sink is supplied.
 func runMakeOnBastion(
 	ctx context.Context,
 	db *gorm.DB,
 	c *models.Cluster,
 	target string,
+	sink io.Writer,
 ) (string, error) {
 	logger := log.With().
 		Str("cluster_id", c.ID.String()).
@@ -342,11 +350,16 @@ func runMakeOnBastion(
 		Str("cmd", cmd).
 		Msg("[runMakeOnBastion] executing remote command")
 
-	out, runErr := sess.CombinedOutput(cmd)
-	if runErr != nil {
-		return string(out), wrapSSHError(runErr, string(out))
+	tail := &tailBuffer{max: logMaxTailBytes}
+	var w io.Writer = tail
+	if sink != nil {
+		w = io.MultiWriter(tail, sink)
 	}
-	return string(out), nil
+
+	if runErr := runSSHStreaming(sess, cmd, w); runErr != nil {
+		return tail.String(), wrapSSHError(runErr, tail.String())
+	}
+	return tail.String(), nil
 }
 
 func randomB64URL(n int) (string, error) {

--- a/internal/bg/river.go
+++ b/internal/bg/river.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivertype"
 	"github.com/spf13/viper"
 	"gorm.io/gorm"
 )
@@ -52,6 +53,7 @@ func NewWorkerClient(pool *pgxpool.Pool, d Deps) (*Client, error) {
 	river.AddWorker(workers, &ClusterActionWorker{db: d.DB, baseURL: d.BaseURL})
 	river.AddWorker(workers, &DNSReconcileWorker{db: d.DB})
 	river.AddWorker(workers, &DbBackupWorker{db: d.DB})
+	river.AddWorker(workers, &JobLogsCleanupWorker{db: d.DB})
 	river.AddWorker(workers, &OrgKeySweeperWorker{db: d.DB})
 	river.AddWorker(workers, &TokensCleanupWorker{db: d.DB})
 
@@ -64,6 +66,12 @@ func NewWorkerClient(pool *pgxpool.Pool, d Deps) (*Client, error) {
 			QueueClusters:    {MaxWorkers: 30},
 		},
 		PeriodicJobs: periodicJobs(),
+		// The rescuer reclaims jobs whose attempt started longer ago than this,
+		// and it is purely time based — it has no idea whether a worker is
+		// still alive and working. The default is one hour, which would reap a
+		// cluster_action mid-bootstrap and, because that job is not retryable,
+		// discard it outright. Keep the window above the longest worker Timeout.
+		RescueStuckJobsAfter: rescueWindow(),
 		// Archer had a bespoke cleanup job for this. River expires finished
 		// jobs itself, so the retention windows live here instead.
 		CompletedJobRetentionPeriod: retention("river.completed_retain_days", 7),
@@ -79,16 +87,16 @@ func NewWorkerClient(pool *pgxpool.Pool, d Deps) (*Client, error) {
 func periodicJobs() []*river.PeriodicJob {
 	return []*river.PeriodicJob{
 		river.NewPeriodicJob(
-			river.PeriodicInterval(interval("bastion.interval_seconds", 10*time.Second)),
+			river.PeriodicInterval(interval("bastion.interval_seconds", 30*time.Second)),
 			func() (river.JobArgs, *river.InsertOpts) {
-				return BastionBootstrapArgs{}, nil
+				return BastionBootstrapArgs{}, &river.InsertOpts{UniqueOpts: tickUnique}
 			},
 			&river.PeriodicJobOpts{ID: "bootstrap_bastion", RunOnStart: true},
 		),
 		river.NewPeriodicJob(
-			river.PeriodicInterval(interval("dns.interval_seconds", 10*time.Second)),
+			river.PeriodicInterval(interval("dns.interval_seconds", 30*time.Second)),
 			func() (river.JobArgs, *river.InsertOpts) {
-				return DNSReconcileArgs{}, nil
+				return DNSReconcileArgs{}, &river.InsertOpts{UniqueOpts: tickUnique}
 			},
 			&river.PeriodicJobOpts{ID: "dns_reconcile", RunOnStart: true},
 		),
@@ -107,6 +115,13 @@ func periodicJobs() []*river.PeriodicJob {
 			&river.PeriodicJobOpts{ID: "db_backup_s3"},
 		),
 		river.NewPeriodicJob(
+			dailyAt(4, 15),
+			func() (river.JobArgs, *river.InsertOpts) {
+				return JobLogsCleanupArgs{}, nil
+			},
+			&river.PeriodicJobOpts{ID: "job_logs_cleanup"},
+		),
+		river.NewPeriodicJob(
 			dailyAt(3, 45),
 			func() (river.JobArgs, *river.InsertOpts) {
 				return TokensCleanupArgs{}, nil
@@ -114,6 +129,16 @@ func periodicJobs() []*river.PeriodicJob {
 			&river.PeriodicJobOpts{ID: "tokens_cleanup"},
 		),
 	}
+}
+
+// tickUnique stops reconcile ticks from stacking up. Under archer each worker
+// enqueued its own successor, so exactly one tick existed at a time. River's
+// PeriodicInterval inserts on a wall clock regardless of whether the previous
+// tick finished, so an 8 minute bastion bootstrap would otherwise queue dozens
+// of redundant ticks against the same queue cluster_action runs on.
+var tickUnique = river.UniqueOpts{
+	ByArgs:  true,
+	ByState: []rivertype.JobState{rivertype.JobStateAvailable, rivertype.JobStateScheduled, rivertype.JobStateRunning, rivertype.JobStateRetryable, rivertype.JobStatePending},
 }
 
 // dailyAtSchedule fires once per day at a fixed local wall-clock time.
@@ -134,11 +159,34 @@ func dailyAt(hour, minute int) river.PeriodicSchedule {
 	return dailyAtSchedule{hour: hour, minute: minute}
 }
 
+// maxWorkerTimeout is the longest Timeout any registered worker returns. Keep
+// this in step with the Timeout methods; ClusterActionWorker is the outlier.
+const maxWorkerTimeout = 168 * time.Hour
+
+// rescueWindow keeps stuck-job rescue comfortably clear of legitimately
+// long-running work, while still reclaiming genuinely abandoned jobs.
+func rescueWindow() time.Duration {
+	if h := viper.GetInt("river.rescue_after_hours"); h > 0 {
+		return time.Duration(h) * time.Hour
+	}
+	return maxWorkerTimeout + time.Hour
+}
+
 func interval(key string, def time.Duration) time.Duration {
 	if s := viper.GetInt(key); s > 0 {
 		return time.Duration(s) * time.Second
 	}
 	return def
+}
+
+// jobLogRetainDays is how long a job transcript is kept. Longer than River's
+// own job retention, because the transcript is usually what someone comes back
+// for after a failure.
+func jobLogRetainDays() int {
+	if d := viper.GetInt("job_logs.retain_days"); d > 0 {
+		return d
+	}
+	return 14
 }
 
 func retention(key string, defDays int) time.Duration {

--- a/internal/bg/river.go
+++ b/internal/bg/river.go
@@ -49,6 +49,7 @@ func NewInsertClient(pool *pgxpool.Pool) (*Client, error) {
 func NewWorkerClient(pool *pgxpool.Pool, d Deps) (*Client, error) {
 	workers := river.NewWorkers()
 
+	river.AddWorker(workers, &BastionSweepWorker{db: d.DB})
 	river.AddWorker(workers, &BastionBootstrapWorker{db: d.DB})
 	river.AddWorker(workers, &ClusterActionWorker{db: d.DB, baseURL: d.BaseURL})
 	river.AddWorker(workers, &DNSReconcileWorker{db: d.DB})
@@ -86,12 +87,16 @@ func NewWorkerClient(pool *pgxpool.Pool, d Deps) (*Client, error) {
 // double-insert.
 func periodicJobs() []*river.PeriodicJob {
 	return []*river.PeriodicJob{
+		// The sweep only claims and dispatches; the bootstraps themselves run
+		// as one job per server on the clusters queue, which is what restores
+		// archer's 30-way concurrency after the port collapsed it to a single
+		// serial tick.
 		river.NewPeriodicJob(
 			river.PeriodicInterval(interval("bastion.interval_seconds", 30*time.Second)),
 			func() (river.JobArgs, *river.InsertOpts) {
-				return BastionBootstrapArgs{}, &river.InsertOpts{UniqueOpts: tickUnique}
+				return BastionSweepArgs{}, &river.InsertOpts{UniqueOpts: tickUnique}
 			},
-			&river.PeriodicJobOpts{ID: "bootstrap_bastion", RunOnStart: true},
+			&river.PeriodicJobOpts{ID: "bastion_sweep", RunOnStart: true},
 		),
 		river.NewPeriodicJob(
 			river.PeriodicInterval(interval("dns.interval_seconds", 30*time.Second)),

--- a/internal/bg/sshexec.go
+++ b/internal/bg/sshexec.go
@@ -1,0 +1,73 @@
+package bg
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// tailBuffer keeps only the last max bytes written to it.
+//
+// Remote commands here can run for hours and emit far more output than is
+// worth holding, but the recent tail is exactly what an error message needs.
+type tailBuffer struct {
+	mu  sync.Mutex
+	b   []byte
+	max int
+}
+
+func (t *tailBuffer) Write(p []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.b = append(t.b, p...)
+	if t.max > 0 && len(t.b) > t.max {
+		t.b = t.b[len(t.b)-t.max:]
+	}
+	return len(p), nil
+}
+
+func (t *tailBuffer) String() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return string(t.b)
+}
+
+// runSSHStreaming runs cmd and copies its combined output to w as it arrives,
+// rather than buffering until exit the way (*ssh.Session).CombinedOutput does.
+//
+// That difference is the whole point: a `make bootstrap` can run for hours, and
+// with CombinedOutput nothing is observable until it finishes — and on success
+// the output was discarded entirely.
+func runSSHStreaming(sess *ssh.Session, cmd string, w io.Writer) error {
+	stdout, err := sess.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+	stderr, err := sess.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("stderr pipe: %w", err)
+	}
+
+	if err := sess.Start(cmd); err != nil {
+		return fmt.Errorf("start remote command: %w", err)
+	}
+
+	// Both pipes must be drained fully before Wait, or Wait can block and the
+	// remote side can stall on a full window.
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	pump := func(r io.Reader) {
+		defer wg.Done()
+		_, _ = io.Copy(w, r)
+	}
+	go pump(stdout)
+	go pump(stderr)
+
+	wg.Wait()
+
+	return sess.Wait()
+}

--- a/internal/handlers/cluster_runs.go
+++ b/internal/handlers/cluster_runs.go
@@ -219,7 +219,15 @@ func RunClusterAction(db *gorm.DB, jobs *bg.Client) http.HandlerFunc {
 			Action:     action.MakeTarget,
 			MakeTarget: action.MakeTarget,
 		}
-		enqueueErr := bg.Insert(r.Context(), jobs, args, nil)
+		insertRes, enqueueErr := jobs.Insert(r.Context(), args, nil)
+		if enqueueErr == nil && insertRes != nil && insertRes.Job != nil {
+			// Correlate the run with its River job so the logs endpoint and the
+			// River dashboard can be cross-referenced.
+			jobID := insertRes.Job.ID
+			_ = db.Model(&models.ClusterRun{}).
+				Where("id = ?", run.ID).
+				Update("job_id", jobID).Error
+		}
 
 		if enqueueErr != nil {
 			_ = db.Model(&models.ClusterRun{}).

--- a/internal/handlers/dto/clusters.go
+++ b/internal/handlers/dto/clusters.go
@@ -22,9 +22,9 @@ type ClusterResponse struct {
 	LastError             string                `json:"last_error"`
 	RandomToken           string                `json:"random_token"`
 	CertificateKey        string                `json:"certificate_key"`
-	NodePools             []NodePoolResponse  `json:"node_pools,omitempty"`
-	Metadata              map[string]string   `json:"metadata,omitempty"`
-	DockerImage           string                    `json:"docker_image"`
+	NodePools             []NodePoolResponse    `json:"node_pools,omitempty"`
+	Metadata              map[string]string     `json:"metadata,omitempty"`
+	DockerImage           string                `json:"docker_image"`
 	DockerTag             string                `json:"docker_tag"`
 	Kubeconfig            *string               `json:"kubeconfig,omitempty"`
 	OrgKey                *string               `json:"org_key,omitempty"`

--- a/internal/handlers/dto/job_logs.go
+++ b/internal/handlers/dto/job_logs.go
@@ -1,0 +1,25 @@
+package dto
+
+import "time"
+
+// JobLogChunk is one batched piece of output from a background job.
+// swagger:model JobLogChunk
+type JobLogChunk struct {
+	ID        int64     `json:"id" example:"1042"`
+	Stream    string    `json:"stream" example:"stdout" enums:"stdout,system"`
+	Chunk     string    `json:"chunk"`
+	CreatedAt time.Time `json:"created_at" format:"date-time"`
+}
+
+// JobLogPage is a cursor page of job output.
+//
+// Poll by passing the previous `next_cursor` back as `after`. When `done` is
+// true the underlying work has finished and no further output will appear, so
+// the client can stop polling.
+//
+// swagger:model JobLogPage
+type JobLogPage struct {
+	Items      []JobLogChunk `json:"items"`
+	NextCursor int64         `json:"next_cursor" example:"1042"`
+	Done       bool          `json:"done" example:"false"`
+}

--- a/internal/handlers/job_logs.go
+++ b/internal/handlers/job_logs.go
@@ -1,0 +1,220 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/glueops/autoglue/internal/api/httpmiddleware"
+	"github.com/glueops/autoglue/internal/handlers/dto"
+	"github.com/glueops/autoglue/internal/models"
+	"github.com/glueops/autoglue/internal/utils"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const (
+	jobLogDefaultLimit = 200
+	jobLogMaxLimit     = 1000
+)
+
+// readJobLogs returns one cursor page of output for a subject, newest last.
+func readJobLogs(db *gorm.DB, orgID uuid.UUID, subjectType string, subjectID uuid.UUID, after int64, limit int) ([]dto.JobLogChunk, int64, error) {
+	var rows []models.JobLog
+	if err := db.
+		Where("organization_id = ? AND subject_type = ? AND subject_id = ? AND id > ?",
+			orgID, subjectType, subjectID, after).
+		Order("id ASC").
+		Limit(limit).
+		Find(&rows).Error; err != nil {
+		return nil, after, err
+	}
+
+	items := make([]dto.JobLogChunk, 0, len(rows))
+	cursor := after
+	for _, r := range rows {
+		items = append(items, dto.JobLogChunk{
+			ID:        r.ID,
+			Stream:    r.Stream,
+			Chunk:     r.Chunk,
+			CreatedAt: r.CreatedAt,
+		})
+		cursor = r.ID
+	}
+	return items, cursor, nil
+}
+
+// atoiDefault and clamp were generic helpers that happened to live in the
+// archer admin handlers, and went with them when those were removed.
+func atoiDefault(s string, def int) int {
+	if s == "" {
+		return def
+	}
+	if n, err := strconv.Atoi(s); err == nil {
+		return n
+	}
+	return def
+}
+
+func clamp(n, lo, hi int) int {
+	if n < lo {
+		return lo
+	}
+	if n > hi {
+		return hi
+	}
+	return n
+}
+
+func jobLogQuery(r *http.Request) (after int64, limit int) {
+	after, _ = strconv.ParseInt(strings.TrimSpace(r.URL.Query().Get("after")), 10, 64)
+	if after < 0 {
+		after = 0
+	}
+	limit = atoiDefault(r.URL.Query().Get("limit"), jobLogDefaultLimit)
+	return after, clamp(limit, 1, jobLogMaxLimit)
+}
+
+// GetClusterRunLogs godoc
+//
+//	@ID				GetClusterRunLogs
+//	@Summary		Tail the output of a cluster run
+//	@Description	Returns output produced by the run's background job, in order. Poll by passing the previous `next_cursor` as `after`; stop when `done` is true.
+//	@Tags			ClusterRuns
+//	@Produce		json
+//	@Param			X-Org-ID	header		string	false	"Organization UUID"
+//	@Param			clusterID	path		string	true	"Cluster ID"
+//	@Param			runID		path		string	true	"Run ID"
+//	@Param			after		query		int		false	"Return chunks with an id greater than this"	default(0)
+//	@Param			limit		query		int		false	"Maximum chunks to return"						minimum(1)	maximum(1000)	default(200)
+//	@Success		200			{object}	dto.JobLogPage
+//	@Failure		400			{string}	string	"bad request"
+//	@Failure		401			{string}	string	"Unauthorized"
+//	@Failure		403			{string}	string	"organization required"
+//	@Failure		404			{string}	string	"not found"
+//	@Failure		500			{string}	string	"db error"
+//	@Router			/clusters/{clusterID}/runs/{runID}/logs [get]
+//	@Security		BearerAuth
+//	@Security		OrgKeyAuth
+//	@Security		OrgSecretAuth
+func GetClusterRunLogs(db *gorm.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		orgID, ok := httpmiddleware.OrgIDFrom(r.Context())
+		if !ok {
+			utils.WriteError(w, http.StatusForbidden, "org_required", "specify X-Org-ID")
+			return
+		}
+
+		clusterID, err := uuid.Parse(chi.URLParam(r, "clusterID"))
+		if err != nil {
+			utils.WriteError(w, http.StatusBadRequest, "bad_cluster_id", "invalid cluster id")
+			return
+		}
+		runID, err := uuid.Parse(chi.URLParam(r, "runID"))
+		if err != nil {
+			utils.WriteError(w, http.StatusBadRequest, "bad_run_id", "invalid run id")
+			return
+		}
+
+		// The run must exist and belong to this org and cluster. Without this
+		// the org filter on job_logs alone would let a caller read any run in
+		// their own org by guessing ids.
+		var run models.ClusterRun
+		if err := db.
+			Where("id = ? AND organization_id = ? AND cluster_id = ?", runID, orgID, clusterID).
+			First(&run).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "not_found", "run not found")
+				return
+			}
+			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
+			return
+		}
+
+		after, limit := jobLogQuery(r)
+		items, cursor, err := readJobLogs(db, orgID, models.JobLogSubjectClusterRun, runID, after, limit)
+		if err != nil {
+			utils.WriteError(w, http.StatusInternalServerError, "db_error", err.Error())
+			return
+		}
+
+		done := run.Status != models.ClusterRunStatusRunning && run.Status != models.ClusterRunStatusQueued
+
+		utils.WriteJSON(w, http.StatusOK, dto.JobLogPage{
+			Items:      items,
+			NextCursor: cursor,
+			// Only report done once the reader has caught up, otherwise a
+			// client that stops on `done` can miss the final chunks.
+			Done: done && len(items) < limit,
+		})
+	}
+}
+
+// GetServerLogs godoc
+//
+//	@ID				GetServerLogs
+//	@Summary		Tail the bootstrap output of a server
+//	@Description	Returns output produced by background jobs acting on this server, most usefully the bastion bootstrap. Poll by passing the previous `next_cursor` as `after`; stop when `done` is true.
+//	@Tags			Servers
+//	@Produce		json
+//	@Param			X-Org-ID	header		string	false	"Organization UUID"
+//	@Param			id			path		string	true	"Server ID"
+//	@Param			after		query		int		false	"Return chunks with an id greater than this"	default(0)
+//	@Param			limit		query		int		false	"Maximum chunks to return"						minimum(1)	maximum(1000)	default(200)
+//	@Success		200			{object}	dto.JobLogPage
+//	@Failure		400			{string}	string	"bad request"
+//	@Failure		401			{string}	string	"Unauthorized"
+//	@Failure		403			{string}	string	"organization required"
+//	@Failure		404			{string}	string	"not found"
+//	@Failure		500			{string}	string	"db error"
+//	@Router			/servers/{id}/logs [get]
+//	@Security		BearerAuth
+//	@Security		OrgKeyAuth
+//	@Security		OrgSecretAuth
+func GetServerLogs(db *gorm.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		orgID, ok := httpmiddleware.OrgIDFrom(r.Context())
+		if !ok {
+			utils.WriteError(w, http.StatusForbidden, "org_required", "specify X-Org-ID")
+			return
+		}
+
+		serverID, err := uuid.Parse(chi.URLParam(r, "id"))
+		if err != nil {
+			utils.WriteError(w, http.StatusBadRequest, "id_invalid", "invalid id")
+			return
+		}
+
+		var server models.Server
+		if err := db.
+			Where("id = ? AND organization_id = ?", serverID, orgID).
+			First(&server).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				utils.WriteError(w, http.StatusNotFound, "server_not_found", "server not found")
+				return
+			}
+			utils.WriteError(w, http.StatusInternalServerError, "db_error", "db error")
+			return
+		}
+
+		after, limit := jobLogQuery(r)
+		items, cursor, err := readJobLogs(db, orgID, models.JobLogSubjectServer, serverID, after, limit)
+		if err != nil {
+			utils.WriteError(w, http.StatusInternalServerError, "db_error", err.Error())
+			return
+		}
+
+		// "pending" means it is waiting for a tick to claim it, so more output
+		// is still coming; only a terminal status ends the stream.
+		status := strings.ToLower(server.Status)
+		done := status == "ready" || status == "failed"
+
+		utils.WriteJSON(w, http.StatusOK, dto.JobLogPage{
+			Items:      items,
+			NextCursor: cursor,
+			Done:       done && len(items) < limit,
+		})
+	}
+}

--- a/internal/handlers/job_logs_test.go
+++ b/internal/handlers/job_logs_test.go
@@ -1,0 +1,173 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/glueops/autoglue/internal/api/httpmiddleware"
+	"github.com/glueops/autoglue/internal/common"
+	"github.com/glueops/autoglue/internal/handlers/dto"
+	"github.com/glueops/autoglue/internal/models"
+	"github.com/glueops/autoglue/internal/testutil/pgtest"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+func seedJobLogs(t *testing.T, db *gorm.DB, orgID, subjectID uuid.UUID, subjectType string, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		row := models.JobLog{
+			JobID:          1,
+			OrganizationID: orgID,
+			SubjectType:    subjectType,
+			SubjectID:      subjectID,
+			Stream:         models.JobLogStreamStdout,
+			Chunk:          fmt.Sprintf("chunk-%d\n", i),
+		}
+		if err := db.Create(&row).Error; err != nil {
+			t.Fatalf("seed job log: %v", err)
+		}
+	}
+}
+
+func serverLogsReq(orgID *uuid.UUID, serverID string, query string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/servers/"+serverID+"/logs"+query, nil)
+
+	ctx := r.Context()
+	if orgID != nil {
+		ctx = httpmiddleware.WithOrg(ctx, &models.Organization{ID: *orgID})
+	}
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", serverID)
+	ctx = context.WithValue(ctx, chi.RouteCtxKey, routeCtx)
+	return r.WithContext(ctx)
+}
+
+func decodePage(t *testing.T, rr *httptest.ResponseRecorder) dto.JobLogPage {
+	t.Helper()
+	var page dto.JobLogPage
+	if err := json.Unmarshal(rr.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode page: %v (body=%s)", err, rr.Body.String())
+	}
+	return page
+}
+
+// seedServer creates the minimum server row the handler authorizes against.
+func seedServer(t *testing.T, db *gorm.DB, orgID uuid.UUID, status string) uuid.UUID {
+	t.Helper()
+
+	org := models.Organization{ID: orgID, Name: "org-" + orgID.String()[:8]}
+	if err := db.Create(&org).Error; err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+
+	key := models.SshKey{
+		AuditFields:         common.AuditFields{OrganizationID: orgID},
+		Name:                "k",
+		PublicKey:           "ssh-ed25519 AAAA",
+		EncryptedPrivateKey: "x",
+		PrivateIV:           "x",
+		PrivateTag:          "x",
+		Fingerprint:         uuid.NewString(),
+	}
+	if err := db.Create(&key).Error; err != nil {
+		t.Fatalf("seed ssh key: %v", err)
+	}
+
+	id := uuid.New()
+	if err := db.Exec(
+		`INSERT INTO servers (id, organization_id, ssh_key_id, hostname, private_ip_address, ssh_user, role, status, created_at, updated_at)
+		 VALUES (?, ?, ?, 'host', '10.0.0.1', 'ubuntu', 'bastion', ?, now(), now())`,
+		id, orgID, key.ID, status,
+	).Error; err != nil {
+		t.Fatalf("seed server: %v", err)
+	}
+	return id
+}
+
+func TestGetServerLogs_PagesByCursor(t *testing.T) {
+	db := pgtest.DB(t)
+	orgID := uuid.New()
+	serverID := seedServer(t, db, orgID, "provisioning")
+	seedJobLogs(t, db, orgID, serverID, models.JobLogSubjectServer, 5)
+
+	// First page, capped at 2.
+	rr := httptest.NewRecorder()
+	GetServerLogs(db)(rr, serverLogsReq(&orgID, serverID.String(), "?limit=2"))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rr.Code, rr.Body.String())
+	}
+	first := decodePage(t, rr)
+	if len(first.Items) != 2 {
+		t.Fatalf("first page = %d items, want 2", len(first.Items))
+	}
+	if first.Done {
+		t.Error("done should be withheld while the reader is still behind")
+	}
+
+	// Second page continues from the cursor rather than repeating.
+	rr = httptest.NewRecorder()
+	GetServerLogs(db)(rr, serverLogsReq(&orgID, serverID.String(),
+		fmt.Sprintf("?limit=10&after=%d", first.NextCursor)))
+	second := decodePage(t, rr)
+	if len(second.Items) != 3 {
+		t.Fatalf("second page = %d items, want the remaining 3", len(second.Items))
+	}
+	if second.Items[0].Chunk != "chunk-2\n" {
+		t.Errorf("second page starts at %q, want chunk-2 (cursor did not advance)", second.Items[0].Chunk)
+	}
+}
+
+func TestGetServerLogs_DoneOnlyWhenTerminalAndCaughtUp(t *testing.T) {
+	db := pgtest.DB(t)
+	orgID := uuid.New()
+	serverID := seedServer(t, db, orgID, "ready")
+	seedJobLogs(t, db, orgID, serverID, models.JobLogSubjectServer, 3)
+
+	// Terminal status, but the reader has a full page: done must stay false or
+	// a client that stops here loses the tail.
+	rr := httptest.NewRecorder()
+	GetServerLogs(db)(rr, serverLogsReq(&orgID, serverID.String(), "?limit=3"))
+	if page := decodePage(t, rr); page.Done {
+		t.Error("done = true while the page was full; client would miss later chunks")
+	}
+
+	// Caught up on a terminal server: now it is safe to stop.
+	rr = httptest.NewRecorder()
+	GetServerLogs(db)(rr, serverLogsReq(&orgID, serverID.String(), "?limit=10"))
+	if page := decodePage(t, rr); !page.Done {
+		t.Error("done = false for a ready server with the reader caught up")
+	}
+}
+
+func TestGetServerLogs_DoesNotLeakAcrossOrgs(t *testing.T) {
+	db := pgtest.DB(t)
+
+	orgA := uuid.New()
+	serverA := seedServer(t, db, orgA, "provisioning")
+	seedJobLogs(t, db, orgA, serverA, models.JobLogSubjectServer, 3)
+
+	orgB := uuid.New()
+	_ = seedServer(t, db, orgB, "provisioning")
+
+	// Org B asking for org A's server must 404, not return its output.
+	rr := httptest.NewRecorder()
+	GetServerLogs(db)(rr, serverLogsReq(&orgB, serverA.String(), ""))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for another org's server", rr.Code)
+	}
+}
+
+func TestGetServerLogs_RequiresOrg(t *testing.T) {
+	db := pgtest.DB(t)
+	rr := httptest.NewRecorder()
+	GetServerLogs(db)(rr, serverLogsReq(nil, uuid.NewString(), ""))
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 without an org", rr.Code)
+	}
+}

--- a/internal/models/cluster.go
+++ b/internal/models/cluster.go
@@ -17,33 +17,33 @@ const (
 )
 
 type Cluster struct {
-	ID                      uuid.UUID     `gorm:"type:uuid;default:gen_random_uuid();primaryKey" json:"id"`
-	OrganizationID          uuid.UUID     `gorm:"type:uuid;not null" json:"organization_id"`
-	Organization            Organization  `gorm:"foreignKey:OrganizationID;constraint:OnDelete:CASCADE" json:"organization"`
-	Name                    string        `gorm:"not null" json:"name"`
-	Provider                string        `json:"provider"`
-	Region                  string        `json:"region"`
-	Status                  string        `gorm:"type:varchar(20);not null;default:'pre_pending'" json:"status"`
-	LastError               string        `gorm:"type:text;not null;default:''" json:"last_error"`
-	CaptainDomainID         *uuid.UUID    `gorm:"type:uuid" json:"captain_domain_id"`
-	CaptainDomain           Domain        `gorm:"foreignKey:CaptainDomainID" json:"captain_domain"`
-	ControlPlaneRecordSetID *uuid.UUID    `gorm:"type:uuid" json:"control_plane_record_set_id,omitempty"`
-	ControlPlaneRecordSet   *RecordSet    `gorm:"foreignKey:ControlPlaneRecordSetID" json:"control_plane_record_set,omitempty"`
-	AppsLoadBalancerID      *uuid.UUID    `gorm:"type:uuid" json:"apps_load_balancer_id,omitempty"`
-	AppsLoadBalancer        *LoadBalancer `gorm:"foreignKey:AppsLoadBalancerID" json:"apps_load_balancer,omitempty"`
-	GlueOpsLoadBalancerID   *uuid.UUID    `gorm:"type:uuid" json:"glueops_load_balancer_id,omitempty"`
-	GlueOpsLoadBalancer     *LoadBalancer `gorm:"foreignKey:GlueOpsLoadBalancerID" json:"glueops_load_balancer,omitempty"`
-	BastionServerID         *uuid.UUID    `gorm:"type:uuid" json:"bastion_server_id,omitempty"`
-	BastionServer           *Server       `gorm:"foreignKey:BastionServerID" json:"bastion_server,omitempty"`
+	ID                      uuid.UUID         `gorm:"type:uuid;default:gen_random_uuid();primaryKey" json:"id"`
+	OrganizationID          uuid.UUID         `gorm:"type:uuid;not null" json:"organization_id"`
+	Organization            Organization      `gorm:"foreignKey:OrganizationID;constraint:OnDelete:CASCADE" json:"organization"`
+	Name                    string            `gorm:"not null" json:"name"`
+	Provider                string            `json:"provider"`
+	Region                  string            `json:"region"`
+	Status                  string            `gorm:"type:varchar(20);not null;default:'pre_pending'" json:"status"`
+	LastError               string            `gorm:"type:text;not null;default:''" json:"last_error"`
+	CaptainDomainID         *uuid.UUID        `gorm:"type:uuid" json:"captain_domain_id"`
+	CaptainDomain           Domain            `gorm:"foreignKey:CaptainDomainID" json:"captain_domain"`
+	ControlPlaneRecordSetID *uuid.UUID        `gorm:"type:uuid" json:"control_plane_record_set_id,omitempty"`
+	ControlPlaneRecordSet   *RecordSet        `gorm:"foreignKey:ControlPlaneRecordSetID" json:"control_plane_record_set,omitempty"`
+	AppsLoadBalancerID      *uuid.UUID        `gorm:"type:uuid" json:"apps_load_balancer_id,omitempty"`
+	AppsLoadBalancer        *LoadBalancer     `gorm:"foreignKey:AppsLoadBalancerID" json:"apps_load_balancer,omitempty"`
+	GlueOpsLoadBalancerID   *uuid.UUID        `gorm:"type:uuid" json:"glueops_load_balancer_id,omitempty"`
+	GlueOpsLoadBalancer     *LoadBalancer     `gorm:"foreignKey:GlueOpsLoadBalancerID" json:"glueops_load_balancer,omitempty"`
+	BastionServerID         *uuid.UUID        `gorm:"type:uuid" json:"bastion_server_id,omitempty"`
+	BastionServer           *Server           `gorm:"foreignKey:BastionServerID" json:"bastion_server,omitempty"`
 	NodePools               []NodePool        `gorm:"many2many:cluster_node_pools;constraint:OnDelete:CASCADE" json:"node_pools,omitempty"`
 	Metadata                []ClusterMetadata `gorm:"foreignKey:ClusterID;constraint:OnDelete:CASCADE" json:"metadata,omitempty"`
 	RandomToken             string            `json:"random_token"`
-	CertificateKey          string        `json:"certificate_key"`
-	EncryptedKubeconfig     string        `gorm:"type:text" json:"-"`
-	KubeIV                  string        `json:"-"`
-	KubeTag                 string        `json:"-"`
-	DockerImage             string        `json:"docker_image"`
-	DockerTag               string        `json:"docker_tag"`
-	CreatedAt               time.Time     `json:"created_at,omitempty" gorm:"type:timestamptz;column:created_at;not null;default:now()"`
-	UpdatedAt               time.Time     `json:"updated_at,omitempty" gorm:"type:timestamptz;autoUpdateTime;column:updated_at;not null;default:now()"`
+	CertificateKey          string            `json:"certificate_key"`
+	EncryptedKubeconfig     string            `gorm:"type:text" json:"-"`
+	KubeIV                  string            `json:"-"`
+	KubeTag                 string            `json:"-"`
+	DockerImage             string            `json:"docker_image"`
+	DockerTag               string            `json:"docker_tag"`
+	CreatedAt               time.Time         `json:"created_at,omitempty" gorm:"type:timestamptz;column:created_at;not null;default:now()"`
+	UpdatedAt               time.Time         `json:"updated_at,omitempty" gorm:"type:timestamptz;autoUpdateTime;column:updated_at;not null;default:now()"`
 }

--- a/internal/models/cluster_runs.go
+++ b/internal/models/cluster_runs.go
@@ -21,7 +21,9 @@ type ClusterRun struct {
 	Action         string    `json:"action" gorm:"type:text;not null"`
 	Status         string    `json:"status" gorm:"type:text;not null"`
 	Error          string    `json:"error" gorm:"type:text;not null"`
-	CreatedAt      time.Time `json:"created_at,omitempty" gorm:"type:timestamptz;column:created_at;not null;default:now()" format:"date-time"`
-	UpdatedAt      time.Time `json:"updated_at,omitempty" gorm:"type:timestamptz;autoUpdateTime;column:updated_at;not null;default:now()" format:"date-time"`
-	FinishedAt     time.Time `json:"finished_at,omitempty" gorm:"type:timestamptz" format:"date-time"`
+	// JobID is the River job executing this run, so logs can be correlated.
+	JobID      *int64    `json:"job_id,omitempty" gorm:"index"`
+	CreatedAt  time.Time `json:"created_at,omitempty" gorm:"type:timestamptz;column:created_at;not null;default:now()" format:"date-time"`
+	UpdatedAt  time.Time `json:"updated_at,omitempty" gorm:"type:timestamptz;autoUpdateTime;column:updated_at;not null;default:now()" format:"date-time"`
+	FinishedAt time.Time `json:"finished_at,omitempty" gorm:"type:timestamptz" format:"date-time"`
 }

--- a/internal/models/job_log.go
+++ b/internal/models/job_log.go
@@ -1,0 +1,49 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Log subjects. A job log is attached to whatever the user would go looking
+// for it under, not to the job: a bastion bootstrap has no ClusterRun, and a
+// single tick bootstraps several servers.
+const (
+	JobLogSubjectServer     = "server"
+	JobLogSubjectClusterRun = "cluster_run"
+)
+
+// Log streams.
+const (
+	JobLogStreamStdout = "stdout"
+	JobLogStreamSystem = "system"
+)
+
+// JobLog is one chunk of output produced by a background job.
+//
+// Rows are append-only and the autoincrement ID doubles as the polling cursor:
+// a reader asks for everything with id > after. Chunks are batched by the
+// writer rather than written per line, so a chatty `make` target does not turn
+// into thousands of INSERTs.
+type JobLog struct {
+	ID int64 `gorm:"primaryKey;autoIncrement" json:"id"`
+
+	// JobID is the River job that produced this output. Zero when the writer
+	// had no job context.
+	JobID int64 `gorm:"not null;default:0;index" json:"job_id"`
+
+	// OrganizationID scopes reads. Carried on the row so the log endpoints do
+	// not have to join back through the subject to authorize.
+	OrganizationID uuid.UUID `gorm:"type:uuid;not null;index:idx_job_logs_subject,priority:1" json:"organization_id"`
+
+	SubjectType string    `gorm:"type:text;not null;index:idx_job_logs_subject,priority:2" json:"subject_type"`
+	SubjectID   uuid.UUID `gorm:"type:uuid;not null;index:idx_job_logs_subject,priority:3" json:"subject_id"`
+
+	Stream string `gorm:"type:text;not null;default:'stdout'" json:"stream"`
+	Chunk  string `gorm:"type:text;not null" json:"chunk"`
+
+	CreatedAt time.Time `gorm:"type:timestamptz;not null;default:now();index" json:"created_at"`
+}
+
+func (JobLog) TableName() string { return "job_logs" }

--- a/internal/testutil/pgtest/pgtest.go
+++ b/internal/testutil/pgtest/pgtest.go
@@ -115,6 +115,7 @@ func initDB() {
 		&models.Action{},
 		&models.ClusterRun{},
 		&models.ClusterMetadata{},
+		&models.JobLog{},
 	); err != nil {
 		initErr = fmt.Errorf("migrate: %w", err)
 		return

--- a/ui/src/api/clusters.ts
+++ b/ui/src/api/clusters.ts
@@ -173,6 +173,11 @@ export const clustersApi = {
       return await clusterRuns.listClusterRuns({ clusterID })
     }),
 
+  getClusterRunLogs: (clusterID: string, runID: string, after: number, limit?: number) =>
+    withRefresh(async () => {
+      return await clusterRuns.getClusterRunLogs({ clusterID, runID, after, limit })
+    }),
+
   getClusterRun: (clusterID: string, runID: string) =>
     withRefresh(async () => {
       return await clusterRuns.getClusterRun({ clusterID, runID })

--- a/ui/src/api/servers.ts
+++ b/ui/src/api/servers.ts
@@ -13,6 +13,11 @@ export const serversApi = {
     withRefresh(async () => {
       return await servers.createServer({ createServerRequest: body })
     }),
+  getServerLogs: (id: string, after: number, limit?: number) =>
+    withRefresh(async () => {
+      return await servers.getServerLogs({ id, after, limit })
+    }),
+
   getServer: (id: string) =>
     withRefresh(async () => {
       return await servers.getServer({ id })

--- a/ui/src/components/job-log-viewer.tsx
+++ b/ui/src/components/job-log-viewer.tsx
@@ -1,0 +1,159 @@
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import type { DtoJobLogPage } from "@/sdk"
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react"
+
+const POLL_INTERVAL_MS = 1500
+const MAX_RENDERED_LINES = 5000
+
+type JobLogLine = {
+  key: string
+  text: string
+  system: boolean
+}
+
+type Props = {
+  /** Fetches one page from the cursor. Must be stable, or polling restarts. */
+  fetchPage: (after: number) => Promise<DtoJobLogPage>
+  /** Poll while true. Pass false to load once, e.g. for a finished run. */
+  live?: boolean
+  className?: string
+  emptyMessage?: string
+}
+
+/**
+ * Tails a background job's output.
+ *
+ * Chunks are appended by cursor rather than refetched, so a long bootstrap does
+ * not re-download its whole transcript every poll. Polling stops when the API
+ * reports `done`, which it withholds until the reader has caught up.
+ */
+export function JobLogViewer({
+  fetchPage,
+  live = true,
+  className,
+  emptyMessage = "No output yet.",
+}: Props) {
+  const [lines, setLines] = useState<JobLogLine[]>([])
+  const [done, setDone] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [follow, setFollow] = useState(true)
+
+  const cursorRef = useRef(0)
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  // Guards against two polls overlapping if one response is slow.
+  const inFlightRef = useRef(false)
+
+  const poll = useCallback(async () => {
+    if (inFlightRef.current) return
+    inFlightRef.current = true
+    try {
+      const page = await fetchPage(cursorRef.current)
+      const items = page.items ?? []
+
+      if (items.length > 0) {
+        setLines((prev) => {
+          const next = [...prev]
+          for (const item of items) {
+            const system = item.stream === "system"
+            const body = item.chunk ?? ""
+            // A chunk is a batch of output, not a line: split so the viewer can
+            // cap what it renders without cutting mid-line.
+            for (const text of body.split("\n")) {
+              if (text === "" ) continue
+              next.push({ key: `${item.id}-${next.length}`, text, system })
+            }
+          }
+          return next.length > MAX_RENDERED_LINES
+            ? next.slice(next.length - MAX_RENDERED_LINES)
+            : next
+        })
+      }
+
+      if (typeof page.next_cursor === "number") cursorRef.current = page.next_cursor
+      if (page.done) setDone(true)
+      setError(null)
+    } catch (e: any) {
+      setError(e?.message ?? "Failed to load logs")
+    } finally {
+      inFlightRef.current = false
+    }
+  }, [fetchPage])
+
+  useEffect(() => {
+    void poll()
+    if (!live) return
+    const t = setInterval(() => {
+      if (!done) void poll()
+    }, POLL_INTERVAL_MS)
+    return () => clearInterval(t)
+  }, [poll, live, done])
+
+  // Stick to the bottom while following. useLayoutEffect so the jump happens
+  // before paint rather than as a visible lurch.
+  useLayoutEffect(() => {
+    if (!follow) return
+    const el = scrollRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [lines, follow])
+
+  const onScroll = () => {
+    const el = scrollRef.current
+    if (!el) return
+    // Re-arm following only when the user returns to the bottom themselves.
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 24
+    setFollow(atBottom)
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-2", className)}>
+      <div className="text-muted-foreground flex items-center gap-2 text-xs">
+        <span
+          className={cn(
+            "inline-block size-2 rounded-full",
+            done ? "bg-muted-foreground" : "animate-pulse bg-emerald-500",
+          )}
+          aria-hidden
+        />
+        <span>{done ? "Finished" : "Streaming"}</span>
+        <span className="ml-auto tabular-nums">{lines.length} lines</span>
+        {!follow && (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-6 px-2 text-xs"
+            onClick={() => setFollow(true)}
+          >
+            Jump to latest
+          </Button>
+        )}
+      </div>
+
+      {error && <p className="text-destructive text-xs">{error}</p>}
+
+      <div
+        ref={scrollRef}
+        onScroll={onScroll}
+        role="log"
+        aria-live="polite"
+        className="bg-muted/40 h-80 overflow-auto rounded-md border p-3 font-mono text-xs leading-relaxed"
+      >
+        {lines.length === 0 ? (
+          <p className="text-muted-foreground">{emptyMessage}</p>
+        ) : (
+          lines.map((l) => (
+            <div
+              key={l.key}
+              className={cn(
+                "break-all whitespace-pre-wrap",
+                l.system && "text-muted-foreground italic",
+              )}
+            >
+              {l.text}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/ui/src/pages/cluster-page.tsx
+++ b/ui/src/pages/cluster-page.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { actionsApi } from "@/api/actions";
+import { JobLogViewer } from "@/components/job-log-viewer";
 import { clustersApi } from "@/api/clusters";
 import { dnsApi } from "@/api/dns";
 import { loadBalancersApi } from "@/api/loadbalancers";
@@ -8,7 +9,7 @@ import { serversApi } from "@/api/servers";
 import type { DtoActionResponse, DtoClusterMetadataResponse, DtoClusterResponse, DtoClusterRunResponse, DtoDomainResponse, DtoLoadBalancerResponse, DtoNodePoolResponse, DtoRecordSetResponse, DtoServerResponse } from "@/sdk";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertCircle, CheckCircle2, CircleSlash2, FileCode2, Globe2, Key, Loader2, MapPin, Pencil, Plus, Save, Search, Server, Wrench, X } from "lucide-react";
+import { AlertCircle, CheckCircle2, CircleSlash2, FileCode2, Globe2, Key, Loader2, MapPin, Pencil, Plus, Save, ScrollText, Search, Server, Wrench, X } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -113,6 +114,56 @@ function StatusBadge({ status }: { status?: string | null }) {
     <Badge variant="outline" className="text-xs">
       {value}
     </Badge>
+  )
+}
+
+function RunLogsDialog({
+  clusterID,
+  runID,
+  title,
+  status,
+}: {
+  clusterID: string
+  runID: string
+  title: string
+  status?: string | null
+}) {
+  const [open, setOpen] = useState(false)
+
+  // Stable per run, so opening the dialog does not restart polling on every
+  // parent re-render.
+  const fetchPage = useCallback(
+    (after: number) => clustersApi.getClusterRunLogs(clusterID, runID, after),
+    [clusterID, runID],
+  )
+
+  const s = (status ?? "").toLowerCase()
+  const live = s === "running" || s === "queued"
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="ghost" className="h-7 px-2 text-xs">
+          <ScrollText className="mr-1 size-3.5" />
+          View
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {title}
+            <RunStatusBadge status={status} />
+          </DialogTitle>
+        </DialogHeader>
+        {open && (
+          <JobLogViewer
+            fetchPage={fetchPage}
+            live={live}
+            emptyMessage="No output recorded for this run."
+          />
+        )}
+      </DialogContent>
+    </Dialog>
   )
 }
 
@@ -1106,6 +1157,7 @@ export const ClustersPage = () => {
                             <TableHead>Created</TableHead>
                             <TableHead>Finished</TableHead>
                             <TableHead>Error</TableHead>
+                            <TableHead className="w-[90px] text-right">Logs</TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody>
@@ -1132,6 +1184,16 @@ export const ClustersPage = () => {
                               </TableCell>
                               <TableCell className="text-xs">
                                 {r.error ? truncateMiddle(r.error, 80) : "-"}
+                              </TableCell>
+                              <TableCell className="text-right">
+                                {configCluster?.id && r.id && (
+                                  <RunLogsDialog
+                                    clusterID={configCluster.id}
+                                    runID={r.id}
+                                    title={runDisplayName(r)}
+                                    status={r.status}
+                                  />
+                                )}
                               </TableCell>
                             </TableRow>
                           ))}

--- a/ui/src/pages/server-page.tsx
+++ b/ui/src/pages/server-page.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { serversApi } from "@/api/servers.ts"
+import { JobLogViewer } from "@/components/job-log-viewer"
 import { sshApi } from "@/api/ssh.ts"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { formatDistanceToNow } from "date-fns"
-import { Plus, Search } from "lucide-react"
+import { Plus, ScrollText, Search } from "lucide-react"
 import { useForm, useWatch } from "react-hook-form"
 import { toast } from "sonner"
 import { z } from "zod"
@@ -100,6 +101,52 @@ const updateServerSchema = z
     }
   })
 type UpdateServerValues = z.input<typeof updateServerSchema>
+
+function ServerLogsDialog({
+  serverID,
+  hostname,
+  status,
+}: {
+  serverID: string
+  hostname?: string
+  status: Status
+}) {
+  const [open, setOpen] = useState(false)
+
+  const fetchPage = useCallback(
+    (after: number) => serversApi.getServerLogs(serverID, after),
+    [serverID],
+  )
+
+  // "pending" means a sweep has not claimed it yet, so output is still coming.
+  const live = status === "pending" || status === "provisioning"
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <ScrollText className="mr-1 size-3.5" />
+          Logs
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <span className="truncate">{hostname ?? "Server"}</span>
+            <StatusBadge status={status} />
+          </DialogTitle>
+        </DialogHeader>
+        {open && (
+          <JobLogViewer
+            fetchPage={fetchPage}
+            live={live}
+            emptyMessage="No bootstrap output recorded for this server yet."
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
 
 function StatusBadge({ status }: { status: Status }) {
   const v =
@@ -645,6 +692,11 @@ export const ServerPage = () => {
                       </TableCell>
                       <TableCell className="text-right">
                         <div className="flex justify-end gap-2">
+                          <ServerLogsDialog
+                            serverID={k.id}
+                            hostname={k.hostname}
+                            status={(k.status ?? "pending") as Status}
+                          />
                           <Button variant="outline" size="sm" onClick={() => openEdit(k)}>
                             Edit
                           </Button>


### PR DESCRIPTION
Draft — backend is complete and verified; the SPA log viewer is still to come.

## Why

Background job output was effectively unreachable. Both SSH paths used `(*ssh.Session).CombinedOutput`, which **buffers until the command exits**, so a multi-hour `make bootstrap` produced nothing observable until it finished — and on success the transcript was **discarded entirely**. On failure only the last 800 bytes reached the worker's stdout, which since the API/worker split means hunting through a worker pod that may have restarted.

## Streaming

New `job_logs` table: append-only, autoincrement id doubles as the polling cursor, keyed by River job id with a polymorphic subject so bastion bootstrap (which has no `ClusterRun`) and cluster actions share one mechanism.

- `LogSink` batches writes, flushing at 4KB or 1s, keeping a bounded 64KB tail for error messages. Losing a log line never fails the job.
- `runSSHStreaming` replaces `CombinedOutput`, pumping stdout and stderr concurrently and draining both before `Wait`.
- Output is persisted on **success as well as failure**.
- `GET /clusters/{clusterID}/runs/{runID}/logs` and `GET /servers/{id}/logs` return cursor pages, org-scoped, with a `done` flag so clients stop polling. `done` is withheld until the reader has caught up, so a client can't stop and miss the final chunks.
- `ClusterRun` gains `job_id`. `job_logs_cleanup` prunes daily (14 day default).

## Bastion concurrency — a regression from the archer port

Archer ran `bootstrap_bastion` with **30 instances and a 168h timeout**. The port collapsed it into **one periodic job with a 1h timeout** that claimed *every* pending bastion and bootstrapped them **serially** at 8 minutes each.

Past ~7 servers the job hit its timeout mid-batch, and because the claim flips a server to `provisioning` up front, every server it never reached was **stranded there permanently** — nothing reclaims `provisioning`, so those hosts became invisible to later ticks.

Split in two, matching the intended contract (`pending` = enqueue, `provisioning` = claimed):

- `bastion_sweep` — periodic, unique, cheap. Claims pending → provisioning and dispatches one job per server. A failed dispatch returns the server to `pending` rather than stranding it.
- `bootstrap_bastion` — takes a `ServerID`, does one host, own 30m timeout, own log sink, unique by args so the same host is never bootstrapped twice concurrently (which would deadlock on remote apt/dpkg locks).

## Other fixes from the archer port

- **`river.RecordOutput` in every worker**, replacing the structured results archer persisted to `jobs.result`. Restores `ClusterActionResult` and `OrgKeySweeperResult`, which the port deleted.
- **`RescueStuckJobsAfter`** now exceeds the longest worker `Timeout`. River's rescuer is purely time-based with no liveness check, so the 1h default would reap a `cluster_action` mid-bootstrap and, since it isn't retryable, **discard it outright**.
- **Reconcile ticks are unique per state and slowed to 30s.** Archer's self-rescheduling chain meant exactly one tick existed at a time; `PeriodicInterval` inserts on a wall clock regardless, so an 8-minute bootstrap queued dozens of redundant ticks onto the queue `cluster_action` shares.
- Restores `atoiDefault`/`clamp`, generic helpers removed with the archer admin handlers.

## Verification

`go build`, `go vet`, `go test` clean. New `tailBuffer` tests run under `-race`, including the concurrent stdout/stderr write pattern the pumps actually use. Swagger and both SDKs regenerated; `getClusterRunLogs` and `getServerLogs` are present in the TS client.

## Remaining

SPA log viewer polling the cursor endpoints from the cluster page and the server view.

Note: `internal/models/cluster.go` and `internal/handlers/dto/clusters.go` carry formatting-only churn from `make swagger`'s `swag fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)