### PR TITLE
fix(bastion): log early failures to job_logs, ignore local credential files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,10 @@ sketch
 # End of https://www.toptal.com/developers/gitignore/api/go,react,intellij+all
 
 .env
+# Local credential files used to hit a live environment by hand. These carry an
+# org key and secret; keep both spellings ignored.
+profile.json
+projile.json
 config.yaml
 go_*_WhiteSpaceConflict/
 notes.txt

--- a/internal/bg/bastion.go
+++ b/internal/bg/bastion.go
@@ -191,11 +191,18 @@ func (w *BastionBootstrapWorker) Work(ctx context.Context, j *river.Job[BastionB
 		return err
 	}
 
-	fail := func(step string, err error, sink *LogSink) error {
-		if sink != nil {
-			sink.System("bootstrap failed at " + step + ": " + err.Error())
-			_ = sink.Close()
-		}
+	// Open the sink before the first thing that can fail. A bastion with no
+	// public IP, or an org key that will not decrypt, are the two most likely
+	// early failures — and previously neither wrote anything to job_logs, so
+	// the UI showed "no output recorded" and the reason stayed in worker
+	// stdout, which is exactly what this is meant to replace.
+	sink := NewLogSink(db, j.ID, s.OrganizationID, models.JobLogSubjectServer, s.ID)
+	defer func() { _ = sink.Close() }()
+
+	sink.System(fmt.Sprintf("claimed bastion %s (%s)", s.ID, s.Hostname))
+
+	fail := func(step string, err error) error {
+		sink.System("bootstrap failed at " + step + ": " + err.Error())
 		logHostErr(jobID, &s, step, err)
 		_ = setServerStatus(db, s.ID, "failed")
 		// The failure is recorded on the server row and in job_logs; returning
@@ -206,7 +213,7 @@ func (w *BastionBootstrapWorker) Work(ctx context.Context, j *river.Job[BastionB
 
 	// 1) Defensive IP check
 	if s.PublicIPAddress == nil || *s.PublicIPAddress == "" {
-		return fail("ip_check", fmt.Errorf("missing public ip"), nil)
+		return fail("ip_check", fmt.Errorf("missing public ip"))
 	}
 
 	// 2) Decrypt private key for org
@@ -218,15 +225,14 @@ func (w *BastionBootstrapWorker) Work(ctx context.Context, j *river.Job[BastionB
 		db,
 	)
 	if err != nil {
-		return fail("decrypt_key", err, nil)
+		return fail("decrypt_key", err)
 	}
 
 	// 3) SSH + install docker. Output streams into job_logs under this server,
 	// so a failed bootstrap can be read back from the API instead of hunting
 	// through worker pod stdout for a truncated tail.
 	host := net.JoinHostPort(*s.PublicIPAddress, "22")
-	sink := NewLogSink(db, j.ID, s.OrganizationID, models.JobLogSubjectServer, s.ID)
-	sink.System(fmt.Sprintf("bootstrapping bastion %s (%s) as %s", s.ID, host, s.SSHUser))
+	sink.System(fmt.Sprintf("connecting to %s as %s", host, s.SSHUser))
 
 	out, err := sshInstallDockerWithOutput(ctx, db, &s, host, s.SSHUser, []byte(privKey), sink)
 	if err != nil {
@@ -234,16 +240,15 @@ func (w *BastionBootstrapWorker) Work(ctx context.Context, j *river.Job[BastionB
 		if len(tail) > 800 {
 			tail = tail[len(tail)-800:]
 		}
-		return fail("ssh_install", fmt.Errorf("%v | tail=%q", err, tail), sink)
+		return fail("ssh_install", fmt.Errorf("%v | tail=%q", err, tail))
 	}
 
 	// 4) Mark ready
 	if err := setServerStatus(db, s.ID, "ready"); err != nil {
-		return fail("set_ready", err, sink)
+		return fail("set_ready", err)
 	}
 
 	sink.System("bastion ready")
-	_ = sink.Close()
 
 	log.Info().Str("server_id", s.ID.String()).
 		Int64("elapsed_ms", time.Since(start).Milliseconds()).


### PR DESCRIPTION
## Early bastion failures wrote nothing to `job_logs`

In v0.12.0 the log sink was opened *after* the IP check and key decryption:

```
209:  return fail("ip_check", ..., nil)      ← no sink
221:  return fail("decrypt_key", err, nil)   ← no sink
228:  sink := NewLogSink(...)                ← opened here
```

So the two most likely early failures — a bastion with no public IP, and an org key that won't decrypt — produced **zero** rows. The server went `failed`, and the viewer you'd open to find out why said *"No bootstrap output recorded for this server yet."* The reason stayed in worker stdout, which is exactly what the streaming work was meant to replace.

Opens the sink immediately after loading the server so every failure path narrates into `job_logs`, and closes it with `defer` instead of at each exit. Adds a claim line and a connect line, so a bootstrap that stalls shows *where* it stalled rather than going quiet.

## Ignore local credential files

`profile.json` / `projile.json` are local files carrying an org key and secret for hitting a live environment by hand. They were untracked but **not ignored**, so one `git add -A` would have staged them. Verified both spellings are now caught:

```
.gitignore:136:profile.json    profile.json
.gitignore:137:projile.json    projile.json
```

Neither has ever been committed on any branch — checked before changing anything.

`go build`, `go vet`, `go test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)