### PR TITLE
chore(build): trim the docker context, and make clean actually clean the spec

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,44 @@
+# Build context hygiene.
+#
+# NOTE: .git is deliberately NOT ignored. The version ldflags come from
+# `git describe` (see VERSION in the Makefile), so excluding it silently
+# stamps every image "dev" with no other symptom.
+
+# --- Secrets and local-only config -------------------------------------------
+# These would otherwise be copied into the builder layer and cached there.
+.env
+.env.*
+!.env.example
+config.yaml
+profile.json
+projile.json
+
+# --- Regenerated during the build --------------------------------------------
+# `make clean` wipes these anyway, and `make ui` / `make sdk-*` rebuild them.
+ui/node_modules
+ui/dist
+ui/.yarn/cache
+ui/.yarn/install-state.gz
+ui/src/sdk
+internal/web/dist
+sdk
+# The spec is generated from Go annotations by `make swagger`, whose rule is
+# mtime based. A stale copy in the context newer than the sources silently
+# skips regeneration and builds the whole image against the wrong spec.
+docs/openapi.*
+docs/swagger.*
+docs/docs.go
+
+# --- Not used by the image ---------------------------------------------------
 terraform
 terraform-provider-autoglue
-sdk
+.terraform
+.terraform.lock*
+terraform.tfstate*
+repomix-output.xml
+.dragon-buddy
+.github
+.idea
+.vscode
+.DS_Store
+*.log

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ sdk: sdk-go ## Alias for sdk-go
 # --- clean/help ---
 clean: ## Clean build artifacts, Swagger outputs, UI dist, and SDKs
 	@echo ">> Cleaning artifacts..."
-	@rm -rf "$(BIN)" docs/swagger.* docs/docs.go \
+	@rm -rf "$(BIN)" docs/swagger.* docs/openapi.* docs/docs.go \
 		"$(UI_DEST_DIR)/dist" "$(UI_DIR)/dist" "$(UI_DIR)/node_modules" \
 		"$(SDK_OUTDIR_CLEAN)" "$(SDK_TS_DIR_CLEAN)" "$(SDK_TS_UI_DIR_CLEAN)"
 


### PR DESCRIPTION
## Context was 765M

`ui/node_modules` alone is **635M**, shipped on every build for nothing — the Dockerfile runs `make ui`, which does its own install. Also excludes `internal/web/dist` (22M), the generated SDKs, `repomix-output.xml`, and editor noise. None of it survives `make clean` anyway.

Adds `.env`, `config.yaml`, `profile.json` and `projile.json`, which were being copied into the builder layer and cached there.

**`.git` is deliberately NOT excluded.** It's 99M and looks like the obvious cut, but the version ldflags come from `git describe` — dropping it silently stamps every image `Version: dev` with no other symptom. Verified the published v0.12.1 binary does carry a real version today, so this is a live property worth protecting:

```
$ strings <extracted v0.12.1 binary> | grep '^v0\.12'
v0.12.1
```

## A real bug found while testing this

```make
clean:
	@rm -rf "$(BIN)" docs/swagger.* docs/docs.go ...
```

`make clean` removes `docs/swagger.*` — but the Makefile *renames* swagger.json into **`docs/openapi.json`**, which clean never deletes. The swagger rule is mtime-based (`$(DOCS_JSON): $(GO_SRCS)`), so a surviving `openapi.json` newer than the Go sources **skips regeneration entirely** and builds the whole image against a stale spec, producing SDKs that don't match the API.

CI is masked from this only because a fresh checkout has no `openapi.json` at all. A local `docker build` after any local `make swagger` is poisoned.

Reproduced: the build failed on `tsc` against a stale generated SDK —

```
src/api/servers.ts(18,28): error TS2551: Property 'getServerLogs' does not exist on type 'ServersApi'
```

Fixed by adding `docs/openapi.*` to `clean`, and belt-and-braces by excluding the generated spec from the build context so regeneration can't be skipped.

## Verification

Full `docker build` from a worktree seeded with a realistic dirty checkout (node_modules, dist, stale generated spec): fails before the fix, passes after. `make ui` runs `tsc`, so a passing build is itself proof the spec is being regenerated. Resulting image runs and lists both `serve` and `worker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)