### PR TITLE
fix(clusters): carry ids and org ids into nested cluster response items

### DIFF
--- a/internal/mapper/cluster.go
+++ b/internal/mapper/cluster.go
@@ -85,6 +85,12 @@ func NodePoolToDTO(np models.NodePool) dto.NodePoolResponse {
 	labels := make([]dto.LabelResponse, 0, len(np.Labels))
 	for _, l := range np.Labels {
 		labels = append(labels, dto.LabelResponse{
+			AuditFields: common.AuditFields{
+				ID:             l.ID,
+				OrganizationID: l.OrganizationID,
+				CreatedAt:      l.CreatedAt,
+				UpdatedAt:      l.UpdatedAt,
+			},
 			Key:   l.Key,
 			Value: l.Value,
 		})
@@ -93,6 +99,12 @@ func NodePoolToDTO(np models.NodePool) dto.NodePoolResponse {
 	annotations := make([]dto.AnnotationResponse, 0, len(np.Annotations))
 	for _, a := range np.Annotations {
 		annotations = append(annotations, dto.AnnotationResponse{
+			AuditFields: common.AuditFields{
+				ID:             a.ID,
+				OrganizationID: a.OrganizationID,
+				CreatedAt:      a.CreatedAt,
+				UpdatedAt:      a.UpdatedAt,
+			},
 			Key:   a.Key,
 			Value: a.Value,
 		})
@@ -101,9 +113,13 @@ func NodePoolToDTO(np models.NodePool) dto.NodePoolResponse {
 	taints := make([]dto.TaintResponse, 0, len(np.Taints))
 	for _, t := range np.Taints {
 		taints = append(taints, dto.TaintResponse{
-			Key:    t.Key,
-			Value:  t.Value,
-			Effect: t.Effect,
+			ID:             t.ID,
+			OrganizationID: t.OrganizationID,
+			Key:            t.Key,
+			Value:          t.Value,
+			Effect:         t.Effect,
+			CreatedAt:      t.CreatedAt.UTC().Format(time.RFC3339),
+			UpdatedAt:      t.UpdatedAt.UTC().Format(time.RFC3339),
 		})
 	}
 
@@ -131,6 +147,7 @@ func NodePoolToDTO(np models.NodePool) dto.NodePoolResponse {
 func ServerToDTO(s models.Server) dto.ServerResponse {
 	return dto.ServerResponse{
 		ID:               s.ID,
+		OrganizationID:   s.OrganizationID,
 		Hostname:         s.Hostname,
 		PrivateIPAddress: s.PrivateIPAddress,
 		PublicIPAddress:  s.PublicIPAddress,

--- a/internal/mapper/cluster_test.go
+++ b/internal/mapper/cluster_test.go
@@ -1,0 +1,99 @@
+package mapper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/glueops/autoglue/internal/common"
+	"github.com/glueops/autoglue/internal/models"
+	"github.com/google/uuid"
+)
+
+// The cluster response nests labels, annotations, taints and servers. Those
+// nested copies used to carry only key/value, so every id and organization_id
+// came back as the zero UUID — a consumer reading a cluster could see a label
+// but had no id to delete or patch it with, and org-owned rows looked unowned.
+func TestNodePoolToDTO_CarriesIdentityIntoNestedItems(t *testing.T) {
+	orgID := uuid.New()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	labelID, annID, taintID, serverID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+
+	np := models.NodePool{
+		AuditFields: common.AuditFields{
+			ID: uuid.New(), OrganizationID: orgID, CreatedAt: now, UpdatedAt: now,
+		},
+		Name: "worker-pool",
+		Role: "worker",
+		Labels: []models.Label{{
+			AuditFields: common.AuditFields{
+				ID: labelID, OrganizationID: orgID, CreatedAt: now, UpdatedAt: now,
+			},
+			Key: "glueops.dev/role", Value: "glueops-platform",
+		}},
+		Annotations: []models.Annotation{{
+			AuditFields: common.AuditFields{
+				ID: annID, OrganizationID: orgID, CreatedAt: now, UpdatedAt: now,
+			},
+			Key: "note", Value: "hello",
+		}},
+		// models.Taint carries its own fields rather than embedding AuditFields.
+		Taints: []models.Taint{{
+			ID: taintID, OrganizationID: orgID, CreatedAt: now, UpdatedAt: now,
+			Key: "dedicated", Value: "platform", Effect: "NoSchedule",
+		}},
+		Servers: []models.Server{{
+			ID: serverID, OrganizationID: orgID, Hostname: "worker-0",
+			PrivateIPAddress: "10.0.0.1", SSHUser: "cluster", Role: "worker",
+			Status: "pending", CreatedAt: now, UpdatedAt: now,
+		}},
+	}
+
+	got := NodePoolToDTO(np)
+
+	if len(got.Labels) != 1 || got.Labels[0].ID != labelID {
+		t.Errorf("label id = %v, want %v", got.Labels[0].ID, labelID)
+	}
+	if got.Labels[0].OrganizationID != orgID {
+		t.Errorf("label org = %v, want %v", got.Labels[0].OrganizationID, orgID)
+	}
+
+	if len(got.Annotations) != 1 || got.Annotations[0].ID != annID {
+		t.Errorf("annotation id = %v, want %v", got.Annotations[0].ID, annID)
+	}
+	if got.Annotations[0].OrganizationID != orgID {
+		t.Errorf("annotation org = %v, want %v", got.Annotations[0].OrganizationID, orgID)
+	}
+
+	if len(got.Taints) != 1 || got.Taints[0].ID != taintID {
+		t.Errorf("taint id = %v, want %v", got.Taints[0].ID, taintID)
+	}
+	if got.Taints[0].OrganizationID != orgID {
+		t.Errorf("taint org = %v, want %v", got.Taints[0].OrganizationID, orgID)
+	}
+	// Taint timestamps are strings on the DTO, unlike the embedded AuditFields
+	// used by labels and annotations.
+	if got.Taints[0].CreatedAt == "" {
+		t.Error("taint created_at is empty")
+	}
+
+	if len(got.Servers) != 1 || got.Servers[0].ID != serverID {
+		t.Errorf("server id = %v, want %v", got.Servers[0].ID, serverID)
+	}
+	if got.Servers[0].OrganizationID != orgID {
+		t.Errorf("server org = %v, want %v", got.Servers[0].OrganizationID, orgID)
+	}
+}
+
+func TestNodePoolToDTO_EmptyCollectionsSerializeAsLists(t *testing.T) {
+	// These must be non-nil so they marshal as [] rather than null; the SPA
+	// maps over them directly.
+	got := NodePoolToDTO(models.NodePool{Name: "empty", Role: "worker"})
+
+	if got.Labels == nil || got.Annotations == nil || got.Taints == nil || got.Servers == nil {
+		t.Fatalf("nested collections must be empty slices, not nil: %+v", got)
+	}
+	if len(got.Labels) != 0 || len(got.Servers) != 0 {
+		t.Error("expected empty collections for an empty node pool")
+	}
+}


### PR DESCRIPTION
## The bug

The cluster response nests labels, annotations, taints and servers, and `internal/mapper` built those nested copies from key/value alone. Observed live on nonprod:

```
/labels             id=abceedc6-3ee0-4daf-af19-2efa9c59a229  glueops.dev/role=glueops-platform
nested in /clusters id=00000000-0000-0000-0000-000000000000  org=00000000-...
```

Nested labels, annotations and taints all came back with `id` and `organization_id` as the **zero UUID**. Nested servers kept their `id` but lost `organization_id`.

**This isn't cosmetic.** Anything consuming a cluster response can't act on its nested labels or taints — there's no usable id to `DELETE` or `PATCH` with, so a client has to re-fetch `/labels` and match on key/value. The zeroed `organization_id` also makes org-owned rows look unowned.

## The fix

Populates identity and timestamps from the models, matching how the authoritative `/labels`, `/taints` and `/servers` handlers already map them. `models.Taint` carries its own fields rather than embedding `AuditFields`, and its DTO takes RFC3339 strings, so it's mapped accordingly.

## Not a breaking change

The DTOs *always* declared these fields — only the values were missing. Verified the generated schema is unchanged:

```
dto.TaintResponse props: [created_at, effect, id, key, organization_id, updated_at, value]
dto.LabelResponse props: [created_at, id, key, organization_id, updated_at, value]
```

So the OpenAPI spec and both SDKs are untouched. Clients that already read these fields simply start getting real values instead of zeros.

## Tests

Two tests that would have caught it: one asserting identity survives into every nested collection, and one pinning that empty collections stay non-nil so they marshal as `[]` rather than `null` (the SPA maps over them directly).

Long-standing, and unrelated to the recent queue work — found while reading a live `/clusters` response on nonprod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)