### PR TITLE
breaking: update react-resizable-panels to 4.12.1

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -58,7 +58,7 @@
     "react-dom": "^19.2.3",
     "react-hook-form": "^7.70.0",
     "react-icons": "^5.5.0",
-    "react-resizable-panels": "^3.0.6",
+    "react-resizable-panels": "4.12.1",
     "react-router-dom": "^7.11.0",
     "recharts": "2.15.4",
     "sonner": "^2.0.7",

--- a/ui/src/components/ui/resizable.tsx
+++ b/ui/src/components/ui/resizable.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { GripVerticalIcon } from "lucide-react"
 import * as ResizablePrimitive from "react-resizable-panels"
 
@@ -7,17 +6,20 @@ import { cn } from "@/lib/utils"
 function ResizablePanelGroup({
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) {
+}: ResizablePrimitive.GroupProps) {
   return (
-    <ResizablePrimitive.PanelGroup
+    <ResizablePrimitive.Group
       data-slot="resizable-panel-group"
-      className={cn("flex h-full w-full data-[panel-group-direction=vertical]:flex-col", className)}
+      className={cn(
+        "flex h-full w-full aria-[orientation=vertical]:flex-col",
+        className
+      )}
       {...props}
     />
   )
 }
 
-function ResizablePanel({ ...props }: React.ComponentProps<typeof ResizablePrimitive.Panel>) {
+function ResizablePanel({ ...props }: ResizablePrimitive.PanelProps) {
   return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />
 }
 
@@ -25,25 +27,25 @@ function ResizableHandle({
   withHandle,
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+}: ResizablePrimitive.SeparatorProps & {
   withHandle?: boolean
 }) {
   return (
-    <ResizablePrimitive.PanelResizeHandle
+    <ResizablePrimitive.Separator
       data-slot="resizable-handle"
       className={cn(
-        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+        "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90",
         className
       )}
       {...props}
     >
       {withHandle && (
-        <div className="bg-border z-10 flex h-4 w-3 items-center justify-center rounded-xs border">
+        <div className="z-10 flex h-4 w-3 items-center justify-center rounded-xs border bg-border">
           <GripVerticalIcon className="size-2.5" />
         </div>
       )}
-    </ResizablePrimitive.PanelResizeHandle>
+    </ResizablePrimitive.Separator>
   )
 }
 
-export { ResizablePanelGroup, ResizablePanel, ResizableHandle }
+export { ResizableHandle, ResizablePanel, ResizablePanelGroup }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -8001,13 +8001,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resizable-panels@npm:^3.0.6":
-  version: 3.0.6
-  resolution: "react-resizable-panels@npm:3.0.6"
+"react-resizable-panels@npm:4.12.1":
+  version: 4.12.1
+  resolution: "react-resizable-panels@npm:4.12.1"
   peerDependencies:
-    react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  checksum: 10/cacd2a0a63e4ecca193ceb2c8369d760946987c6386e38be39c7f98f909db923f161dbfd5187c289f5093c035c4a7757c4bd30b0d792bd8b45f2bc64183fe47f
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  checksum: 10/70bbc47d9788946018661bf16b209560a2588d72e98383f823814ec13ce5559b3f8ad7ef2d76d541f8033237644817605f6e51babd5dbb5e47675ba0b89f157e
   languageName: node
   linkType: hard
 
@@ -9319,7 +9319,7 @@ __metadata:
     react-dom: "npm:^19.2.3"
     react-hook-form: "npm:^7.70.0"
     react-icons: "npm:^5.5.0"
-    react-resizable-panels: "npm:^3.0.6"
+    react-resizable-panels: "npm:4.12.1"
     react-router-dom: "npm:^7.11.0"
     recharts: "npm:2.15.4"
     shadcn: "npm:3.8.5"


### PR DESCRIPTION
Supersedes #812.

v4 renames the primitives (`PanelGroup` → `Group`, `PanelResizeHandle` →
`Separator`) and replaces the `data-panel-group-direction` attribute that
`resizable.tsx`'s Tailwind selectors keyed off with `aria-orientation`. #812
failed on the first half of that:

```
src/components/ui/resizable.tsx(10,51): error TS2339:
  Property 'PanelGroup' does not exist on type ...
```

Rather than hand-translate the styling — this component has no importers, so
there is nothing rendering it to check the result against — this takes the
component **shadcn itself now ships for v4** (registry `new-york-v4/resizable`,
which declares `react-resizable-panels@^4`). The file therefore matches what
`shadcn add resizable` would write today, and independently confirms the
attribute translation `data-[panel-group-direction=vertical]` →
`aria-[orientation=vertical]`.

Only deviation from upstream: the `"use client"` directive is dropped, which
this file did not carry before and which is inert in a Vite SPA.

Verified: `yarn build` with **0 TypeScript errors**, all **11 UI tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)