### PR TITLE
fix(ui): clear the set-state-in-effect errors and gate lint in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,41 @@ jobs:
       - name: Test
         working-directory: ui
         run: yarn test
+
+  # Nothing ran eslint on a PR before this job, which is how TypeScript 7
+  # (#1057) merged green and still broke linting outright — typescript-eslint
+  # refuses TS >= 6.1, and it had to be reverted in #1061. The build and the
+  # tests do not exercise the linter, so a toolchain change can pass both while
+  # leaving `yarn lint` unrunnable.
+  #
+  # No SDK generation step here on purpose: eslint.config.js uses
+  # tseslint.configs.recommended, not the type-checked variant, so this does
+  # not resolve types and does not need docs/openapi.json or ui/src/sdk.
+  lint-ui:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      # The UI is on Yarn 4, which is not published to npm; corepack reads the
+      # version from packageManager in ui/package.json.
+      - name: Enable corepack
+        run: npm i -g corepack@0.35.0 && corepack enable
+
+      - name: Install
+        working-directory: ui
+        run: yarn install --immutable
+
+      - name: Lint
+        working-directory: ui
+        run: yarn lint
+
   # govulncheck is reachability-aware: it reports only advisories whose
   # vulnerable symbols are actually called from this code, which is the
   # difference between a list of advisories and a list of problems. It needs

--- a/ui/src/hooks/use-mobile.ts
+++ b/ui/src/hooks/use-mobile.ts
@@ -1,19 +1,28 @@
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
+const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
 
+function subscribe(onStoreChange: () => void) {
+  const mql = window.matchMedia(MOBILE_QUERY)
+  mql.addEventListener("change", onStoreChange)
+  return () => mql.removeEventListener("change", onStoreChange)
+}
+
+function getSnapshot() {
+  return window.innerWidth < MOBILE_BREAKPOINT
+}
+
+// There is no window while server-rendering or pre-hydration. The previous
+// implementation started as `undefined` and coerced to false, so keep false.
+function getServerSnapshot() {
+  return false
+}
+
+// matchMedia is an external store, so subscribing to it with
+// useSyncExternalStore is the direct expression of what this hook does.
+// Reading it into state from an effect instead cost an extra render on mount
+// and reported the wrong value for that first paint.
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }

--- a/ui/src/pages/cluster-page.tsx
+++ b/ui/src/pages/cluster-page.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { actionsApi } from "@/api/actions";
 import { JobLogViewer } from "@/components/job-log-viewer";
 import { clustersApi } from "@/api/clusters";
@@ -469,7 +469,13 @@ export const ClustersPage = () => {
 
   // --- Config dialog helpers ---
 
-  useEffect(() => {
+  // Seed the config dialog's fields from whichever cluster it is opened on.
+  // Adjusting state during render rather than in an effect means the dialog
+  // never paints a frame showing the previously opened cluster's values.
+  const [seededFor, setSeededFor] = useState(configCluster)
+  if (seededFor !== configCluster) {
+    setSeededFor(configCluster)
+
     setMetadataKey("")
     setMetadataValue("")
     setEditingMetadataId(null)
@@ -483,17 +489,16 @@ export const ClustersPage = () => {
       setBastionId("")
       setNodePoolId("")
       setKubeconfigText("")
-      return
+    } else {
+      if (configCluster.captain_domain?.id) setCaptainDomainId(configCluster.captain_domain.id)
+      if (configCluster.control_plane_record_set?.id)
+        setRecordSetId(configCluster.control_plane_record_set.id)
+      if (configCluster.apps_load_balancer?.id) setAppsLbId(configCluster.apps_load_balancer.id)
+      if (configCluster.glueops_load_balancer?.id)
+        setGlueopsLbId(configCluster.glueops_load_balancer.id)
+      if (configCluster.bastion_server?.id) setBastionId(configCluster.bastion_server.id)
     }
-
-    if (configCluster.captain_domain?.id) setCaptainDomainId(configCluster.captain_domain.id)
-    if (configCluster.control_plane_record_set?.id)
-      setRecordSetId(configCluster.control_plane_record_set.id)
-    if (configCluster.apps_load_balancer?.id) setAppsLbId(configCluster.apps_load_balancer.id)
-    if (configCluster.glueops_load_balancer?.id)
-      setGlueopsLbId(configCluster.glueops_load_balancer.id)
-    if (configCluster.bastion_server?.id) setBastionId(configCluster.bastion_server.id)
-  }, [configCluster])
+  }
 
   async function refreshConfigCluster() {
     if (!configCluster?.id) return

--- a/ui/src/pages/dns-page.tsx
+++ b/ui/src/pages/dns-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { credentialsApi } from "@/api/credentials"
 import { dnsApi } from "@/api/dns"
 import type {
@@ -242,7 +242,10 @@ type UpdateRecordValues = z.input<typeof updateRecordSchema>
 
 export const DnsPage = () => {
   const [filter, setFilter] = useState("")
-  const [selected, setSelected] = useState<DtoDomainResponse | null>(null)
+  // Only the user's explicit pick lives in state. The effective selection falls
+  // back to the first domain, which is what the previous effect did by writing
+  // that fallback back into state — including after a delete set it to null.
+  const [selectedOverride, setSelectedOverride] = useState<DtoDomainResponse | null>(null)
 
   const [createDomOpen, setCreateDomOpen] = useState(false)
   const [editDomOpen, setEditDomOpen] = useState(false)
@@ -260,6 +263,8 @@ export const DnsPage = () => {
     queryFn: () => dnsApi.listDomains(),
   })
 
+  const selected = selectedOverride ?? domainsQ.data?.[0] ?? null
+
   const recordsQ = useQuery({
     queryKey: ["dns", "records", selected?.id],
     queryFn: async () => {
@@ -275,12 +280,6 @@ export const DnsPage = () => {
   })
 
   const r53Credentials = useMemo(() => (credentialQ.data ?? []).filter(isR53), [credentialQ.data])
-
-  useEffect(() => {
-    if (!selected && domainsQ.data && domainsQ.data.length) {
-      setSelected(domainsQ.data[0]!)
-    }
-  }, [domainsQ.data, selected])
 
   const filteredDomains = useMemo(() => {
     const list: DtoDomainResponse[] = domainsQ.data ?? []
@@ -313,7 +312,7 @@ export const DnsPage = () => {
       setCreateDomOpen(false)
       createDomainForm.reset()
       await qc.invalidateQueries({ queryKey: ["dns", "domains"] })
-      setSelected(d as DtoDomainResponse)
+      setSelectedOverride(d as DtoDomainResponse)
     },
     onError: (e: any) =>
       toast.error("Failed to create domain", { description: e?.message ?? "Unknown error" }),
@@ -325,7 +324,7 @@ export const DnsPage = () => {
   })
 
   const openEditDomain = (d: DtoDomainResponse) => {
-    setSelected(d)
+    setSelectedOverride(d)
     editDomainForm.reset({
       domain_name: d.domain_name,
       credential_id: d.credential_id,
@@ -364,7 +363,7 @@ export const DnsPage = () => {
     onSuccess: async () => {
       toast.success("Domain deleted")
       await qc.invalidateQueries({ queryKey: ["dns", "domains"] })
-      setSelected(null)
+      setSelectedOverride(null)
     },
     onError: (e: any) =>
       toast.error("Failed to delete domain", { description: e?.message ?? "Unknown error" }),
@@ -605,7 +604,7 @@ export const DnsPage = () => {
                     className={`hover:bg-muted/30 border-t ${
                       selected?.id === d.id ? "bg-muted/40" : ""
                     }`}
-                    onClick={() => setSelected(d)}
+                    onClick={() => setSelectedOverride(d)}
                   >
                     <td className="cursor-pointer px-3 py-2 font-medium">{d.domain_name}</td>
                     <td className="px-3 py-2">{d.zone_id || "—"}</td>

--- a/ui/src/pages/node-pools-page.tsx
+++ b/ui/src/pages/node-pools-page.tsx
@@ -113,10 +113,16 @@ function ManageManyDialog(props: {
   const [selected, setSelected] = useState<Set<string>>(new Set(initialSelectedIds))
   const [saving, setSaving] = useState(false)
 
-  useEffect(() => {
+  // Reset the picker whenever it is reopened, or the incoming selection
+  // changes. Adjusting state during render is React's documented replacement
+  // for doing this in an effect: it re-renders before anything is committed,
+  // so the dialog never paints one frame holding the previous pool's selection.
+  const [lastReset, setLastReset] = useState({ open, initialSelectedIds })
+  if (lastReset.open !== open || lastReset.initialSelectedIds !== initialSelectedIds) {
+    setLastReset({ open, initialSelectedIds })
     setSelected(new Set(initialSelectedIds))
     setQ("")
-  }, [initialSelectedIds, open])
+  }
 
   const filtered = useMemo(() => {
     const qq = q.trim().toLowerCase()


### PR DESCRIPTION
Clears the 4 `react-hooks/set-state-in-effect` errors and adds the CI job that
stops the next one reaching main.

Each error was a different shape of the same mistake — writing state from an
effect that render could have derived.

| File | Was | Now |
| --- | --- | --- |
| `use-mobile.ts` | copied `matchMedia` into state on mount | `useSyncExternalStore` |
| `dns-page.tsx` | effect wrote the first domain into `selected` whenever nothing was selected | selection derived: `selectedOverride ?? domains[0] ?? null` |
| `cluster-page.tsx` | effect reset dialog fields from `configCluster` | adjust state during render, against a previous-value tracker |
| `node-pools-page.tsx` | effect reset picker state on open | same |

Two of these fix real behaviour, not just the lint:

- `useIsMobile` reported **`false` for the first paint regardless of viewport**,
  because state started `undefined` and was only corrected after mount.
- Both dialogs painted one frame still showing the *previously* opened cluster's
  or pool's values, because the effect ran after commit. Adjusting during render
  re-renders before anything is committed.

`useEffect` became unused in `cluster-page.tsx` and `dns-page.tsx`; imports dropped.

### The CI job is the point

**Nothing ran eslint on a PR before this.** That is how TypeScript 7 merged green
in #1057 while breaking linting outright, and had to be reverted in #1061 — the
build and the tests do not exercise the linter, so a toolchain change can pass
both and still leave `yarn lint` unrunnable.

`lint-ui` deliberately has no SDK generation step: `eslint.config.js` uses
`tseslint.configs.recommended`, not the type-checked variant, so it resolves no
types. Verified by running lint with `ui/src/sdk` removed — clean.

Verified: `yarn lint` **clean** (from 4 errors), build clean, **11/11 UI tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)