### PR TITLE
chore(renovate): hold typescript below 7 until typescript-eslint supports it

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": [
+        "Hold TypeScript below 7 until typescript-eslint supports it.",
+        "TS 7 was merged in #1057 and reverted in #1061 the same day: typescript-eslint's latest release declares typescript '>=4.8.4 <6.1.0' and refuses to load against 7.0, which breaks `yarn lint` outright. There is no 9.x or 10.x, so there is no version of this toolchain where TS 7 and a working linter coexist.",
+        "This uses allowedVersions rather than relying on closing the PRs. The org base preset sets recreateWhen: always, so a closed major PR comes straight back - #1017, #1040, #1055 and #1063 were all the same update arriving four times.",
+        "Remove this rule once typescript-eslint ships TS 7 support; the lint-ui CI job added in #1067 will then be what proves it."
+      ],
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
+    }
+  ]
+}


### PR DESCRIPTION
TypeScript 7 was merged in #1057 and reverted in #1061 the same day. It builds
and passes tests, but typescript-eslint refuses to load against it:

```
Error: typescript-eslint does not support TS 7.0.
```

Its latest release declares `"typescript": ">=4.8.4 <6.1.0"`, and there is no 9.x or
10.x — so there is currently no version of this toolchain where TS 7 and a working
`yarn lint` coexist.

### Why a rule and not just closing the PRs

The org base preset sets `recreateWhen: always`, so a closed major comes straight
back. **#1017, #1040, #1055 and #1063 were all the same update arriving four times.**
`allowedVersions` stops Renovate proposing the version at all — the difference
between a decision and a recurring chore.

### On the config shape

This is the repo's first repo-level Renovate config, and it deliberately sets no
`extends`. The org runner (`GlueOps/renovatebot`) injects
`github>GlueOps/renovatebot-configs//base` plus `//auto-merge` via `RENOVATE_FORCE`,
so re-declaring them here would only risk drifting from the version the runner pins
(currently `v0.0.34`).

Since `force` overrides other config, whether a repo-level `packageRules` survives
that merge is a fair question — **GlueOps/waggle answers it**: same runner, same
shape (repo-level `packageRules` with `allowedVersions`, no `extends`), and its
cosign/checkout holds work.

Validated with `renovate-config-validator`: *Config validated successfully*.

Remove this rule once typescript-eslint ships TS 7 support — the `lint-ui` job added
in #1067 is then what proves the upgrade is actually safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)