### PR TITLE
feat(bg): monthly vacuum job, and keep job logs for 45 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Queues:
 | Queue         | Concurrency | Work                                            |
 | ------------- | ----------- | ----------------------------------------------- |
 | `clusters`    | 30          | `cluster_action`, `bootstrap_bastion`           |
-| `maintenance` | 2           | `dns_reconcile`, `db_backup_s3`, `org_key_sweeper`, `tokens_cleanup` |
+| `maintenance` | 2           | `dns_reconcile`, `db_backup_s3`, `org_key_sweeper`, `tokens_cleanup`, `job_logs_cleanup`, `vacuum` |
 | `default`     | 10          | unassigned work                                 |
 
 Long-running cluster work is kept off `maintenance` so a multi-hour bootstrap
@@ -95,6 +95,25 @@ River's own dashboard is mounted at `/admin/river/` behind the platform-admin
 gate, and replaces the old hand-rolled jobs admin page. Retention of finished
 jobs is handled by River itself (`river.completed_retain_days` and friends in
 config), not by a cleanup job.
+
+### Housekeeping schedule
+
+| Job                | When            | What it does                                                  |
+| ------------------ | --------------- | ------------------------------------------------------------- |
+| `tokens_cleanup`   | daily 03:45     | Deletes revoked and expired `refresh_tokens`                   |
+| `job_logs_cleanup` | daily 04:15     | Prunes `job_logs` older than `job_logs.retain_days` (def. 45)  |
+| `vacuum`           | 1st of month 02:30 | `VACUUM (ANALYZE)` over the high-churn tables               |
+
+`vacuum` runs plain `VACUUM`, never `VACUUM FULL`. `FULL` rewrites the table
+under an `ACCESS EXCLUSIVE` lock, which on `river_job` would block the very
+workers fetching from it. Plain `VACUUM` takes only `SHARE UPDATE EXCLUSIVE`, so
+it makes dead space reusable without stopping traffic — the right trade for
+tables that immediately refill that space. The `ANALYZE` half matters just as
+much: the daily cleanups above leave the planner's row estimates badly stale.
+
+Job transcripts outlive the jobs that wrote them on purpose. A River job row is
+a status; `job_logs` is the evidence, and it is what someone comes back for
+weeks after a bootstrap failed — long after the row itself has been expired.
 
 Once you have an org - create a set of api keys for your org:
 They will be in the format of:

--- a/internal/bg/river.go
+++ b/internal/bg/river.go
@@ -57,6 +57,7 @@ func NewWorkerClient(pool *pgxpool.Pool, d Deps) (*Client, error) {
 	river.AddWorker(workers, &JobLogsCleanupWorker{db: d.DB})
 	river.AddWorker(workers, &OrgKeySweeperWorker{db: d.DB})
 	river.AddWorker(workers, &TokensCleanupWorker{db: d.DB})
+	river.AddWorker(workers, &VacuumWorker{db: d.DB})
 
 	return river.NewClient(riverpgxv5.New(pool), &river.Config{
 		Logger:  newLogger(),
@@ -133,6 +134,16 @@ func periodicJobs() []*river.PeriodicJob {
 			},
 			&river.PeriodicJobOpts{ID: "tokens_cleanup"},
 		),
+		// First of the month, at an hour that clears the daily cleanups above:
+		// their bulk deletes are exactly what this is tidying up after, so
+		// running into them would waste the pass.
+		river.NewPeriodicJob(
+			monthlyAt(1, 2, 30),
+			func() (river.JobArgs, *river.InsertOpts) {
+				return VacuumArgs{}, nil
+			},
+			&river.PeriodicJobOpts{ID: "vacuum"},
+		),
 	}
 }
 
@@ -164,6 +175,29 @@ func dailyAt(hour, minute int) river.PeriodicSchedule {
 	return dailyAtSchedule{hour: hour, minute: minute}
 }
 
+// monthlyAtSchedule fires once per month on a fixed day at a fixed local
+// wall-clock time. Keep day at or below 28: time.Date normalizes an overflowing
+// day into the next month, so day 31 in February would silently drift to March.
+type monthlyAtSchedule struct {
+	day    int
+	hour   int
+	minute int
+}
+
+func (s monthlyAtSchedule) Next(t time.Time) time.Time {
+	next := time.Date(t.Year(), t.Month(), s.day, s.hour, s.minute, 0, 0, t.Location())
+	if !next.After(t) {
+		// Month+1 is normalized by time.Date, so December rolls into January of
+		// the following year without special-casing.
+		next = time.Date(t.Year(), t.Month()+1, s.day, s.hour, s.minute, 0, 0, t.Location())
+	}
+	return next
+}
+
+func monthlyAt(day, hour, minute int) river.PeriodicSchedule {
+	return monthlyAtSchedule{day: day, hour: hour, minute: minute}
+}
+
 // maxWorkerTimeout is the longest Timeout any registered worker returns. Keep
 // this in step with the Timeout methods; ClusterActionWorker is the outlier.
 const maxWorkerTimeout = 168 * time.Hour
@@ -184,14 +218,15 @@ func interval(key string, def time.Duration) time.Duration {
 	return def
 }
 
-// jobLogRetainDays is how long a job transcript is kept. Longer than River's
-// own job retention, because the transcript is usually what someone comes back
-// for after a failure.
+// jobLogRetainDays is how long a job transcript is kept. Much longer than
+// River's own job retention: the job row is a status, but the transcript is the
+// evidence, and it is what someone comes back for weeks after a bootstrap went
+// wrong. The row it describes will already have been expired by then.
 func jobLogRetainDays() int {
 	if d := viper.GetInt("job_logs.retain_days"); d > 0 {
 		return d
 	}
-	return 14
+	return 45
 }
 
 func retention(key string, defDays int) time.Duration {

--- a/internal/bg/vacuum.go
+++ b/internal/bg/vacuum.go
@@ -1,0 +1,149 @@
+package bg
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+)
+
+// vacuumTables are the tables worth a scheduled vacuum: everything here is
+// churned hard enough that autovacuum's default 20% scale factor lets a lot of
+// dead tuples accumulate between passes.
+//
+// river_job is the obvious one — every tick job inserts a row and the cleaner
+// deletes it a week later. The leader/queue/client tables are tiny but are
+// UPDATEd on a heartbeat, so their dead-tuple ratio is far worse than their row
+// count suggests. job_logs and refresh_tokens both take bulk deletes from the
+// daily cleanup jobs, which is exactly the pattern that leaves a table full of
+// holes.
+//
+// This list is a constant, never job arguments: VACUUM takes an identifier, and
+// an identifier cannot be a bind parameter.
+var vacuumTables = []string{
+	"river_job",
+	"river_leader",
+	"river_queue",
+	"river_client",
+	"river_client_queue",
+	"job_logs",
+	"refresh_tokens",
+	"cluster_runs",
+}
+
+type VacuumArgs struct{}
+
+func (VacuumArgs) Kind() string { return "vacuum" }
+
+func (VacuumArgs) InsertOpts() river.InsertOpts {
+	// Not retried. A vacuum that failed will be attempted again next month, and
+	// a failing one is usually failing for a reason a retry cannot fix
+	// (ownership, disk) rather than a transient one.
+	return river.InsertOpts{Queue: QueueMaintenance, MaxAttempts: 1}
+}
+
+// VacuumTableResult is one table's outcome, recorded on the job row so the
+// River dashboard shows what actually ran.
+type VacuumTableResult struct {
+	Table   string `json:"table"`
+	Skipped bool   `json:"skipped,omitempty"`
+	Error   string `json:"error,omitempty"`
+	Millis  int64  `json:"millis"`
+}
+
+type VacuumResult struct {
+	Status string              `json:"status"`
+	Tables []VacuumTableResult `json:"tables"`
+}
+
+// VacuumWorker runs VACUUM (ANALYZE) over the high-churn tables.
+//
+// Deliberately not VACUUM FULL. FULL rewrites the table under an ACCESS
+// EXCLUSIVE lock, which would block every read and write to river_job for the
+// duration — on a worker that is fetching jobs from that table, that is a
+// self-inflicted outage. Plain VACUUM takes only SHARE UPDATE EXCLUSIVE, so
+// normal traffic continues; it makes dead space reusable rather than returning
+// it to the OS, which is the right trade for a table that will immediately
+// refill it. The ANALYZE is the other half of the point: after a bulk delete
+// the planner's row estimates are badly stale.
+type VacuumWorker struct {
+	river.WorkerDefaults[VacuumArgs]
+	db *gorm.DB
+}
+
+// Timeout is generous because the cost scales with table size, and this is the
+// one job whose whole purpose is to be slow occasionally rather than fast
+// always. It stays well under RescueStuckJobsAfter.
+func (w *VacuumWorker) Timeout(*river.Job[VacuumArgs]) time.Duration {
+	return time.Hour
+}
+
+func (w *VacuumWorker) Work(ctx context.Context, _ *river.Job[VacuumArgs]) error {
+	results := make([]VacuumTableResult, 0, len(vacuumTables))
+
+	for _, table := range vacuumTables {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		res := VacuumTableResult{Table: table}
+		started := time.Now()
+
+		switch exists, err := tableExists(ctx, w.db, table); {
+		case err != nil:
+			res.Error = err.Error()
+		case !exists:
+			// River's schema varies by migration version, and cluster_runs
+			// predates some deployments. A table we do not have is not a
+			// failure, it is just nothing to do.
+			res.Skipped = true
+		default:
+			res.Error = w.vacuum(ctx, table)
+		}
+
+		res.Millis = time.Since(started).Milliseconds()
+		results = append(results, res)
+
+		switch {
+		case res.Skipped:
+			log.Debug().Str("table", table).Msg("[vacuum] table absent, skipped")
+		case res.Error != "":
+			// One table failing must not cost the rest their vacuum, so this is
+			// recorded and the loop continues.
+			log.Warn().Str("table", table).Str("error", res.Error).Msg("[vacuum] failed")
+		default:
+			log.Info().Str("table", table).Int64("ms", res.Millis).Msg("[vacuum] done")
+		}
+	}
+
+	if err := river.RecordOutput(ctx, VacuumResult{Status: "ok", Tables: results}); err != nil {
+		log.Warn().Err(err).Msg("[vacuum] could not record output")
+	}
+	return nil
+}
+
+func (w *VacuumWorker) vacuum(ctx context.Context, table string) string {
+	// Sanitize even though the input is a package constant: it costs nothing,
+	// and it means adding a name to vacuumTables can never become an injection.
+	stmt := fmt.Sprintf("VACUUM (ANALYZE) %s", pgx.Identifier{table}.Sanitize())
+
+	// VACUUM cannot run inside a transaction block, so this must go through
+	// Exec on the session rather than any Transaction wrapper.
+	if err := w.db.WithContext(ctx).Exec(stmt).Error; err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
+func tableExists(ctx context.Context, db *gorm.DB, table string) (bool, error) {
+	var reg *string
+	err := db.WithContext(ctx).Raw("SELECT to_regclass(?)::text", table).Scan(&reg).Error
+	if err != nil {
+		return false, err
+	}
+	return reg != nil, nil
+}

--- a/internal/bg/vacuum_test.go
+++ b/internal/bg/vacuum_test.go
@@ -1,0 +1,156 @@
+package bg
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/glueops/autoglue/internal/testutil/pgtest"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	pgtest.Stop()
+	os.Exit(code)
+}
+
+// The whole reason this test exists: VACUUM cannot run inside a transaction
+// block, and it goes to Postgres through GORM, which is a layer built almost
+// entirely around wrapping things in transactions. Whether the statement
+// survives that trip is not something to take on faith.
+func TestVacuumRunsThroughGorm(t *testing.T) {
+	db := pgtest.DB(t)
+	ctx := context.Background()
+	w := &VacuumWorker{db: db}
+
+	before := lastVacuum(t, "job_logs")
+
+	if msg := w.vacuum(ctx, "job_logs"); msg != "" {
+		t.Fatalf("vacuum job_logs: %s", msg)
+	}
+
+	// pg_stat is updated by the stats collector, so the timestamp can lag the
+	// statement returning by a moment.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if after := lastVacuum(t, "job_logs"); after != nil && (before == nil || after.After(*before)) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("last_vacuum for job_logs never advanced")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// Every name in vacuumTables must be quotable and, if present, vacuumable. A
+// typo here would otherwise only show up as a warning line once a month.
+func TestVacuumTablesAreAllValid(t *testing.T) {
+	db := pgtest.DB(t)
+	ctx := context.Background()
+	w := &VacuumWorker{db: db}
+
+	for _, table := range vacuumTables {
+		exists, err := tableExists(ctx, db, table)
+		if err != nil {
+			t.Fatalf("tableExists(%s): %v", table, err)
+		}
+		if !exists {
+			// The river_* tables are migrated by River itself, which pgtest
+			// does not run. Absence is the case the worker skips.
+			continue
+		}
+		if msg := w.vacuum(ctx, table); msg != "" {
+			t.Errorf("vacuum %s: %s", table, msg)
+		}
+	}
+}
+
+func TestTableExistsReportsMissingTables(t *testing.T) {
+	db := pgtest.DB(t)
+	ctx := context.Background()
+
+	exists, err := tableExists(ctx, db, "job_logs")
+	if err != nil {
+		t.Fatalf("tableExists(job_logs): %v", err)
+	}
+	if !exists {
+		t.Error("job_logs should exist after migration")
+	}
+
+	exists, err = tableExists(ctx, db, "no_such_table_here")
+	if err != nil {
+		t.Fatalf("tableExists(missing): %v", err)
+	}
+	if exists {
+		t.Error("a table that was never created should not report as existing")
+	}
+}
+
+func TestMonthlyAtRollsForwardAcrossYearBoundary(t *testing.T) {
+	s := monthlyAtSchedule{day: 1, hour: 2, minute: 30}
+
+	cases := []struct {
+		name string
+		from time.Time
+		want time.Time
+	}{
+		{
+			name: "later the same month",
+			from: time.Date(2026, time.March, 10, 9, 0, 0, 0, time.UTC),
+			want: time.Date(2026, time.April, 1, 2, 30, 0, 0, time.UTC),
+		},
+		{
+			name: "earlier on the target day",
+			from: time.Date(2026, time.March, 1, 1, 0, 0, 0, time.UTC),
+			want: time.Date(2026, time.March, 1, 2, 30, 0, 0, time.UTC),
+		},
+		{
+			name: "exactly on the target instant does not return itself",
+			from: time.Date(2026, time.March, 1, 2, 30, 0, 0, time.UTC),
+			want: time.Date(2026, time.April, 1, 2, 30, 0, 0, time.UTC),
+		},
+		{
+			// December + 1 is month 13, which time.Date normalizes.
+			name: "december rolls into january",
+			from: time.Date(2026, time.December, 15, 0, 0, 0, 0, time.UTC),
+			want: time.Date(2027, time.January, 1, 2, 30, 0, 0, time.UTC),
+		},
+		{
+			// The 1st exists in February, unlike the 29th through 31st, which
+			// is exactly why the schedule is pinned to it.
+			name: "january rolls into february",
+			from: time.Date(2026, time.January, 20, 0, 0, 0, 0, time.UTC),
+			want: time.Date(2026, time.February, 1, 2, 30, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := s.Next(tc.from); !got.Equal(tc.want) {
+				t.Errorf("Next(%s) = %s, want %s", tc.from, got, tc.want)
+			}
+		})
+	}
+}
+
+func lastVacuum(t *testing.T, table string) *time.Time {
+	t.Helper()
+
+	// NullTime rather than *time.Time: a table that has never been vacuumed
+	// reports NULL here, which is the expected state at the start of this test
+	// and not something database/sql will scan into a bare pointer.
+	var at sql.NullTime
+	err := pgtest.DB(t).
+		Raw("SELECT last_vacuum FROM pg_stat_user_tables WHERE relname = ?", table).
+		Scan(&at).Error
+	if err != nil {
+		t.Fatalf("read last_vacuum for %s: %v", table, err)
+	}
+	if !at.Valid {
+		return nil
+	}
+	return &at.Time
+}

--- a/internal/testutil/pgtest/pgtest.go
+++ b/internal/testutil/pgtest/pgtest.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"testing"
@@ -45,6 +46,28 @@ func listenPort() uint32 {
 	return port
 }
 
+// runtimePath isolates the extracted Postgres runtime per test binary.
+//
+// `go test ./...` runs packages in parallel, and embedded-postgres does
+// os.RemoveAll on the runtime path at the start of every Start. Two packages
+// sharing the default (~/.embedded-postgres-go/extracted) therefore delete the
+// directory out from under each other mid-extraction, and the loser fails with
+// a rename into a directory that no longer exists. The library's own error text
+// names this fix. It only bites on a cold cache, so it looks fine locally and
+// fails in CI.
+//
+// Only the extracted runtime needs isolating: the downloaded archive is written
+// to a temp file and renamed into the cache, which the library does explicitly
+// to survive concurrent extraction. So this costs one extra unpack, not an
+// extra download.
+//
+// Keyed on the test binary name (bg.test, handlers.test) rather than the PID:
+// unique per package, but stable across runs, so the unpacked copy is still
+// reused instead of being rebuilt every time.
+func runtimePath() string {
+	return filepath.Join(os.TempDir(), "autoglue-pgtest", filepath.Base(os.Args[0]))
+}
+
 var (
 	once    sync.Once
 	epg     *embeddedpostgres.EmbeddedPostgres
@@ -64,6 +87,7 @@ func initDB() {
 		Username("autoglue").
 		Password("autoglue").
 		Port(port).
+		RuntimePath(runtimePath()).
 		StartTimeout(30 * time.Second)
 
 	epg = embeddedpostgres.NewDatabase(cfg)


### PR DESCRIPTION
Adds a `vacuum` job running `VACUUM (ANALYZE)` over the high-churn tables on the 1st of each month, and raises `job_logs` retention from 14 to 45 days.

### Not `VACUUM FULL`

`FULL` rewrites the table under an `ACCESS EXCLUSIVE` lock, which on `river_job` would block the very workers fetching from it — a self-inflicted outage. Plain `VACUUM` takes only `SHARE UPDATE EXCLUSIVE`, so it makes dead space reusable without stopping traffic. That is the right trade for tables that immediately refill the space. The `ANALYZE` half matters just as much: the daily cleanups leave the planner's row estimates badly stale.

### Why 45 days

A River job row is a status; `job_logs` is the evidence, and it is what someone comes back for weeks after a bootstrap failed — long after the row itself has been expired. At 14 days the transcript outlived its job by a week; at 45 it outlives it by more than a month. This is also what gives the vacuum job a target: `job_logs` starts taking the bulk deletes that leave a table full of holes.

### Safety

- Table names are a package constant, never job arguments. `VACUUM` takes an identifier, and an identifier cannot be a bind parameter. Sanitized through `pgx.Identifier` regardless.
- Missing tables are skipped via `to_regclass` — River's schema varies by migration version.
- One table failing does not cost the rest their vacuum; per-table results land on the job row via `river.RecordOutput`.
- `MaxAttempts: 1`. A vacuum that failed will be tried again next month, and the usual causes (ownership, disk) are not fixed by a retry.

### Testing

Against embedded Postgres, because the assumption worth checking was whether `VACUUM` survives GORM at all — it cannot run inside a transaction block, and GORM is built around wrapping things in transactions. It does. Plus month-rollover cases for the new `monthlyAt` schedule, including December into January.

### Context

Current production numbers show autovacuum comfortably keeping up: the whole database is a few MB and everything sits at ~0% dead tuples. This is insurance for growth and for the `ANALYZE`, not a fix for something burning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)